### PR TITLE
Update default port in API swagger

### DIFF
--- a/api/consent-management-API.yaml
+++ b/api/consent-management-API.yaml
@@ -18,14 +18,7 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: http://localhost:3000/api/v1
-    variables:
-      km_host:
-        default: localhost
-        description: Hostname of the Consent Management server.
-      km_port:
-        default: "3000"
-        description: Port number for the Consent Management server.
+  - url: http://localhost:8080/api/v1
 tags:
   - name: Consent Elements
     description: Manage Consent Elements


### PR DESCRIPTION
## Overview

With the addition of support to deploy the service in Choreo via [1], the default port has been updated to 8080. However, this change is not reflected in the Swagger definition, causing errors when directly importing into tools like Postman.

[1] https://github.com/wso2/openfgc/pull/29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API server configuration to use fixed endpoint at `http://localhost:8080/api/v1` instead of the previous configurable setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->