### PR TITLE
Add consent delegation mechanism.

### DIFF
--- a/api/consent-management-API.yaml
+++ b/api/consent-management-API.yaml
@@ -117,6 +117,10 @@ paths:
       description: |
         Provides a powerful search capability to find consents based on various filter criteria like consent type, status, client ID , user ID and time range. Supports pagination.
 
+        When `dataPrincipalId` is provided, the caller must supply the `X-User-ID` header so the
+        server can verify the caller is a registered delegate for the specified principal. Omitting
+        `X-User-ID` while setting `dataPrincipalId` will result in a 403 Forbidden response.
+
       operationId: consents-search-GET
       tags:
         - Consents
@@ -128,6 +132,17 @@ paths:
           schema:
             type: string
             example: "ORG-001"
+        - in: header
+          name: X-User-ID
+          required: false
+          description: |
+            The authenticated user's identifier, set by the API gateway / IdP.
+            **Required when `dataPrincipalId` is provided.** The server uses this value to
+            verify that the caller is an authorised delegate for the specified principal.
+            Omitting this header while supplying `dataPrincipalId` will result in a 403 response.
+          schema:
+            type: string
+            example: "parent-user-id-456"
         - name: consentTypes
           in: query
           description: A comma-separated list of consent types to filter by (e.g., 'accounts,payments').
@@ -206,6 +221,16 @@ paths:
                 $ref: "#/components/schemas/ConsentSearchResponse"
         "400":
           description: Bad Request. The search parameters provided are invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConsentErrorCommon"
+        "403":
+          description: |
+            Forbidden. The caller is not authorised to access the specified principal's consents.
+            This occurs when:
+            - `dataPrincipalId` is set but the `X-User-ID` header is missing.
+            - The caller identified by `X-User-ID` is not a registered delegate for the specified `dataPrincipalId`.
           content:
             application/json:
               schema:
@@ -2727,7 +2752,6 @@ components:
           type: integer
           format: int64
           example: 86400
-
         attributes:
           description: A key-value map of additional, non-standard attributes associated with the consent.
           type: object

--- a/api/consent-management-API.yaml
+++ b/api/consent-management-API.yaml
@@ -2518,7 +2518,7 @@ components:
         Request body for updating a consent.
 
         **Status Derivation:**
-        The consent status is NOT provided in the request. Instead, it is automatically derived by the API based on the API based on the authorization states:
+        The consent status is NOT provided in the request. Instead, it is automatically derived by the API based on the authorization states:
         - If any authorization has status "rejected" → consent status = "rejected"
         - If any authorization has status "created" → consent status = "created"
         - If all authorizations have status "approved" (or empty/default) → consent status = "active"
@@ -3612,7 +3612,7 @@ components:
           example: "child-user-id-123"
         revocationPolicy:
           type: string
-          enum: [ANY, SUBJECT_ONLY]
+          enum: [ANY, SUBJECT_ONLY, BOTH]
           example: "ANY"
         validUntil:
           type: integer

--- a/api/consent-management-API.yaml
+++ b/api/consent-management-API.yaml
@@ -260,6 +260,16 @@ paths:
           schema:
             type: string
           example: "ORG-001"
+        - in: header
+          name: X-User-ID
+          required: true
+          description: |
+            The authenticated user's identifier, set by the API gateway / IdP.
+            Used to verify that the caller is the data principal or an active delegate
+            before returning delegate metadata. Returns 403 if missing or unauthorized.
+          schema:
+            type: string
+          example: "parent-user-id-456"
         - name: consentId
           in: path
           required: true

--- a/api/consent-management-API.yaml
+++ b/api/consent-management-API.yaml
@@ -267,6 +267,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ConsentErrorCommon"
+        "500":
+          description: Internal Server Error. An unexpected error occurred on the server.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConsentErrorCommon"
       security:
         - basicAuth: []
   /consents/attributes:

--- a/api/consent-management-API.yaml
+++ b/api/consent-management-API.yaml
@@ -186,6 +186,17 @@ paths:
             type: integer
             format: int32
           example: 0
+        - name: dataPrincipalId
+          in: query
+          required: false
+          description: |
+            Filter consents by data subject (the person whose data is being processed).
+            Used when a delegate (e.g., parent) queries consents on behalf of another person (e.g., child).
+            The caller must be a registered delegate for the specified principal.
+            Requires the X-User-ID header to be present for authorization verification.
+          schema:
+            type: string
+          example: "child-user-id-123"
       responses:
         "200":
           description: OK. Returns a list of consents matching the search criteria, along with pagination metadata.
@@ -201,6 +212,57 @@ paths:
                 $ref: "#/components/schemas/ConsentErrorCommon"
         "500":
           description: Internal Server Error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConsentErrorCommon"
+      security:
+        - basicAuth: []
+  /consents/{consentId}/delegates:
+    get:
+      summary: Get delegates for a consent
+      description: |
+        Returns all registered delegates for a delegated consent, along with the delegation
+        metadata (principal_id, revocation policy, expiry timestamp).
+        Covers all delegation scenarios: parent→child, carer→disabled adult, power of attorney, etc.
+      operationId: consents-delegates-GET
+      tags:
+        - Consents
+      parameters:
+        - in: header
+          name: org-id
+          required: true
+          schema:
+            type: string
+          example: "ORG-001"
+        - name: consentId
+          in: path
+          required: true
+          description: The unique identifier of the consent.
+          schema:
+            type: string
+          example: "550e8400-e29b-41d4-a716-446655440000"
+      responses:
+        "200":
+          description: OK. Returns the delegate list for this consent.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DelegateListResponse"
+        "400":
+          description: Bad Request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConsentErrorCommon"
+        "403":
+          description: Forbidden. Caller is not authorized.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConsentErrorCommon"
+        "404":
+          description: Consent not found.
           content:
             application/json:
               schema:
@@ -2425,7 +2487,7 @@ components:
         Request body for updating a consent.
 
         **Status Derivation:**
-        The consent status is NOT provided in the request. Instead, it is automatically derived by the API based on the authorization states:
+        The consent status is NOT provided in the request. Instead, it is automatically derived by the API based on the API based on the authorization states:
         - If any authorization has status "rejected" → consent status = "rejected"
         - If any authorization has status "created" → consent status = "created"
         - If all authorizations have status "approved" (or empty/default) → consent status = "active"
@@ -3507,6 +3569,60 @@ components:
             $ref: "#/components/schemas/PurposeResponse"
         metadata:
           $ref: "#/components/schemas/ConsentSearchMetadata"
+    DelegateListResponse:
+      type: object
+      description: Response for GET /consents/{consentId}/delegates
+      properties:
+        consentId:
+          type: string
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        dataPrincipalId:
+          type: string
+          description: userId of the actual data subject (e.g., the child)
+          example: "child-user-id-123"
+        revocationPolicy:
+          type: string
+          enum: [ANY, SUBJECT_ONLY]
+          example: "ANY"
+        validUntil:
+          type: integer
+          format: int64
+          description: Unix timestamp when delegation expires. Absent for permanent delegations.
+          example: 1764547200
+        isDelegationExpired:
+          type: boolean
+          description: True when the current time is past validUntil
+          example: false
+        delegateCount:
+          type: integer
+          example: 2
+        delegates:
+          type: array
+          items:
+            type: object
+            properties:
+              authId:
+                type: string
+              userId:
+                type: string
+                description: The delegate's userId (e.g., the parent's account ID)
+              delegationType:
+                type: string
+                description: Free-form delegation type string
+                example: "parental_biological"
+              status:
+                type: string
+                example: "APPROVED"
+              canRevoke:
+                type: boolean
+              canModify:
+                type: boolean
+              onBehalfOf:
+                type: string
+                description: The principalId this delegate is acting for
+              updatedTime:
+                type: integer
+                format: int64
   securitySchemes:
     basicAuth:
       type: http

--- a/api/consent-management-API.yaml
+++ b/api/consent-management-API.yaml
@@ -3612,6 +3612,11 @@ components:
     DelegateListResponse:
       type: object
       description: Response for GET /consents/{consentId}/delegates
+      required:
+        - consentId
+        - isDelegationExpired
+        - delegateCount
+        - delegates
       properties:
         consentId:
           type: string

--- a/consent-server/internal/consent/ConsentService_mock_test.go
+++ b/consent-server/internal/consent/ConsentService_mock_test.go
@@ -240,9 +240,9 @@ func (_m *MockConsentService) ValidateConsent(ctx context.Context, req model.Val
 	return r0, r1
 }
 
-// GetConsentDelegates provides a mock function with given fields: ctx, consentID, orgID
-func (_m *MockConsentService) GetConsentDelegates(ctx context.Context, consentID string, orgID string) (*model.DelegateListResponse, *serviceerror.ServiceError) {
-	ret := _m.Called(ctx, consentID, orgID)
+// GetConsentDelegates provides a mock function with given fields: ctx, consentID, orgID, callerID
+func (_m *MockConsentService) GetConsentDelegates(ctx context.Context, consentID string, orgID string, callerID string) (*model.DelegateListResponse, *serviceerror.ServiceError) {
+	ret := _m.Called(ctx, consentID, orgID, callerID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetConsentDelegates")
@@ -250,19 +250,19 @@ func (_m *MockConsentService) GetConsentDelegates(ctx context.Context, consentID
 
 	var r0 *model.DelegateListResponse
 	var r1 *serviceerror.ServiceError
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*model.DelegateListResponse, *serviceerror.ServiceError)); ok {
-		return rf(ctx, consentID, orgID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*model.DelegateListResponse, *serviceerror.ServiceError)); ok {
+		return rf(ctx, consentID, orgID, callerID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *model.DelegateListResponse); ok {
-		r0 = rf(ctx, consentID, orgID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *model.DelegateListResponse); ok {
+		r0 = rf(ctx, consentID, orgID, callerID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.DelegateListResponse)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
-		r1 = rf(ctx, consentID, orgID)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) *serviceerror.ServiceError); ok {
+		r1 = rf(ctx, consentID, orgID, callerID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)

--- a/consent-server/internal/consent/ConsentService_mock_test.go
+++ b/consent-server/internal/consent/ConsentService_mock_test.go
@@ -240,6 +240,38 @@ func (_m *MockConsentService) ValidateConsent(ctx context.Context, req model.Val
 	return r0, r1
 }
 
+// GetConsentDelegates provides a mock function with given fields: ctx, consentID, orgID
+func (_m *MockConsentService) GetConsentDelegates(ctx context.Context, consentID string, orgID string) (*model.DelegateListResponse, *serviceerror.ServiceError) {
+	ret := _m.Called(ctx, consentID, orgID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetConsentDelegates")
+	}
+
+	var r0 *model.DelegateListResponse
+	var r1 *serviceerror.ServiceError
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*model.DelegateListResponse, *serviceerror.ServiceError)); ok {
+		return rf(ctx, consentID, orgID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *model.DelegateListResponse); ok {
+		r0 = rf(ctx, consentID, orgID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.DelegateListResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = rf(ctx, consentID, orgID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+
+	return r0, r1
+}
+
 // NewMockConsentService creates a new instance of MockConsentService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockConsentService(t interface {

--- a/consent-server/internal/consent/error_constants.go
+++ b/consent-server/internal/consent/error_constants.go
@@ -104,8 +104,7 @@ var (
 	}
 
 	// ErrorUnauthorized is returned when the caller is not permitted to perform
-	// the requested operation (e.g., accessing another principal's consents without
-	// being a registered delegate). Used by handler_test.go .
+	// the requested operation.
 	ErrorUnauthorized = serviceerror.ServiceError{
 		Type:        serviceerror.ClientErrorType,
 		Code:        "CS-4054",

--- a/consent-server/internal/consent/error_constants.go
+++ b/consent-server/internal/consent/error_constants.go
@@ -64,11 +64,8 @@ var (
 	}
 )
 
-// Delegation errors — used when consent is given on behalf of another person.
-// Covers parent→child, carer→disabled adult, power-of-attorney, etc.
+// Delegation errors.
 var (
-	// ErrorInvalidDelegation is returned when a delegated consent request is
-	// missing required attributes such as principal_id or valid_until.
 	ErrorInvalidDelegation = serviceerror.ServiceError{
 		Type:        serviceerror.ClientErrorType,
 		Code:        "CS-4050",
@@ -76,8 +73,6 @@ var (
 		Description: "Delegated consent is missing required attributes",
 	}
 
-	// ErrorNotAuthorizedForPrincipal is returned when the caller tries to read
-	// another person's consents without being a registered delegate .
 	ErrorNotAuthorizedForPrincipal = serviceerror.ServiceError{
 		Type:        serviceerror.ClientErrorType,
 		Code:        "CS-4051",
@@ -85,8 +80,6 @@ var (
 		Description: "Caller is not a registered delegate for the requested data principal",
 	}
 
-	// ErrorRevocationNotPermitted is returned when the caller does not have
-	// permission to revoke a delegated consent .
 	ErrorRevocationNotPermitted = serviceerror.ServiceError{
 		Type:        serviceerror.ClientErrorType,
 		Code:        "CS-4052",
@@ -94,8 +87,6 @@ var (
 		Description: "Caller does not have permission to revoke this consent",
 	}
 
-	// ErrorDelegationExpired is returned when a delegate tries to act after
-	// guardian.valid_until has passed — only the principal may act now .
 	ErrorDelegationExpired = serviceerror.ServiceError{
 		Type:        serviceerror.ClientErrorType,
 		Code:        "CS-4053",
@@ -103,8 +94,6 @@ var (
 		Description: "The delegation period has ended; only the data principal may act on this consent",
 	}
 
-	// ErrorUnauthorized is returned when the caller is not permitted to perform
-	// the requested operation.
 	ErrorUnauthorized = serviceerror.ServiceError{
 		Type:        serviceerror.ClientErrorType,
 		Code:        "CS-4054",

--- a/consent-server/internal/consent/error_constants.go
+++ b/consent-server/internal/consent/error_constants.go
@@ -63,3 +63,53 @@ var (
 		Description: "An unexpected internal error occurred",
 	}
 )
+
+// Delegation errors — used when consent is given on behalf of another person.
+// Covers parent→child, carer→disabled adult, power-of-attorney, etc.
+var (
+	// ErrorInvalidDelegation is returned when a delegated consent request is
+	// missing required attributes such as principal_id or valid_until.
+	ErrorInvalidDelegation = serviceerror.ServiceError{
+		Type:        serviceerror.ClientErrorType,
+		Code:        "CS-4050",
+		Message:     "Invalid delegation",
+		Description: "Delegated consent is missing required attributes",
+	}
+
+	// ErrorNotAuthorizedForPrincipal is returned when the caller tries to read
+	// another person's consents without being a registered delegate .
+	ErrorNotAuthorizedForPrincipal = serviceerror.ServiceError{
+		Type:        serviceerror.ClientErrorType,
+		Code:        "CS-4051",
+		Message:     "Not authorized for principal",
+		Description: "Caller is not a registered delegate for the requested data principal",
+	}
+
+	// ErrorRevocationNotPermitted is returned when the caller does not have
+	// permission to revoke a delegated consent .
+	ErrorRevocationNotPermitted = serviceerror.ServiceError{
+		Type:        serviceerror.ClientErrorType,
+		Code:        "CS-4052",
+		Message:     "Revocation not permitted",
+		Description: "Caller does not have permission to revoke this consent",
+	}
+
+	// ErrorDelegationExpired is returned when a delegate tries to act after
+	// guardian.valid_until has passed — only the principal may act now .
+	ErrorDelegationExpired = serviceerror.ServiceError{
+		Type:        serviceerror.ClientErrorType,
+		Code:        "CS-4053",
+		Message:     "Delegation expired",
+		Description: "The delegation period has ended; only the data principal may act on this consent",
+	}
+
+	// ErrorUnauthorized is returned when the caller is not permitted to perform
+	// the requested operation (e.g., accessing another principal's consents without
+	// being a registered delegate). Used by handler_test.go .
+	ErrorUnauthorized = serviceerror.ServiceError{
+		Type:        serviceerror.ClientErrorType,
+		Code:        "CS-4054",
+		Message:     "Unauthorized",
+		Description: "Caller is not authorized to perform this operation",
+	}
+)

--- a/consent-server/internal/consent/error_constants.go
+++ b/consent-server/internal/consent/error_constants.go
@@ -94,10 +94,17 @@ var (
 		Description: "The delegation period has ended; only the data principal may act on this consent",
 	}
 
-	ErrorUnauthorized = serviceerror.ServiceError{
+	ErrorForbidden = serviceerror.ServiceError{
 		Type:        serviceerror.ClientErrorType,
 		Code:        "CS-4054",
-		Message:     "Unauthorized",
-		Description: "Caller is not authorized to perform this operation",
+		Message:     "Forbidden",
+		Description: "Caller is not permitted to perform this operation",
+	}
+
+	ErrorModificationNotPermitted = serviceerror.ServiceError{
+		Type:        serviceerror.ClientErrorType,
+		Code:        "CS-4055",
+		Message:     "Modification not permitted",
+		Description: "Caller does not have permission to modify this consent",
 	}
 )

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -63,6 +63,17 @@ func (h *consentHandler) createConsent(w http.ResponseWriter, r *http.Request) {
 	// This field is NOT read from JSON (tagged json:"-")
 	req.CallerID = r.Header.Get("X-User-ID")
 
+	// Propagate the explicitly provided PrincipalID into the attributes map
+	// so that delegation validation and downstream processing can safely use it.
+	if req.PrincipalID != "" {
+		if req.Attributes == nil {
+			req.Attributes = make(map[string]string)
+		}
+		// Uses the canonical constant (e.g. "delegation.principal_id") to ensure the
+		// validator and storage layers interpret the field properly.
+		req.Attributes[model.AttrDelegationPrincipalID] = req.PrincipalID
+	}
+
 	// Validate delegation attributes here in the handler so the check runs even
 	// when the service is mocked in tests. ValidateDelegationAttributes is a no-op
 	// when delegation.type is not present in Attributes.

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -402,10 +402,12 @@ func (h *consentHandler) searchConsentsByAttribute(w http.ResponseWriter, r *htt
 // getDelegates handles GET /consents/{consentId}/delegates
 // Returns all registered delegates for the given consent, along with delegation
 // metadata (principal_id, revocation policy, expiry).
+// Requires X-User-ID header — only the principal or an active delegate may view.
 func (h *consentHandler) getDelegates(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	consentID := r.PathValue("consentId")
 	orgID := r.Header.Get(constants.HeaderOrgID)
+	callerID := strings.TrimSpace(r.Header.Get("X-User-ID"))
 
 	if err := utils.ValidateOrgID(orgID); err != nil {
 		utils.SendError(w, r, serviceerror.CustomServiceError(ErrorValidationFailed, err.Error()))
@@ -417,7 +419,13 @@ func (h *consentHandler) getDelegates(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response, serviceErr := h.service.GetConsentDelegates(ctx, consentID, orgID)
+	if callerID == "" {
+		utils.SendError(w, r, serviceerror.CustomServiceError(ErrorNotAuthorizedForPrincipal,
+			"X-User-ID header is required to view consent delegates"))
+		return
+	}
+
+	response, serviceErr := h.service.GetConsentDelegates(ctx, consentID, orgID, callerID)
 	if serviceErr != nil {
 		utils.SendError(w, r, serviceErr)
 		return

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -62,7 +62,7 @@ func (h *consentHandler) createConsent(w http.ResponseWriter, r *http.Request) {
 	// circular self-delegation (where the delegate being registered is the
 	// same person as the data principal).
 	// This field is NOT read from JSON (tagged json:"-")
-	req.CallerID = r.Header.Get("X-User-ID")
+	req.CallerID = strings.TrimSpace(r.Header.Get("X-User-ID"))
 
 	// Propagate the explicitly provided PrincipalID into the attributes map
 	// so that delegation validation and downstream processing can safely use it.
@@ -172,7 +172,7 @@ func (h *consentHandler) listConsents(w http.ResponseWriter, r *http.Request) {
 
 	// CallerID from X-User-ID header — used to verify the caller is an authorised
 	// delegate when dataPrincipalId is also provided
-	filters.CallerID = r.Header.Get("X-User-ID")
+	filters.CallerID = strings.TrimSpace(r.Header.Get("X-User-ID"))
 
 	// dataPrincipalId filters consents by data subject (the person whose data was
 	// consented to), not by who gave the consent.
@@ -280,7 +280,7 @@ func (h *consentHandler) updateConsent(w http.ResponseWriter, r *http.Request) {
 	// Set CallerID from X-User-ID so UpdateConsent can enforce canModify on
 	// delegated consents. The header is injected by the gateway/IdP and cannot
 	// be spoofed by the client.
-	req.CallerID = r.Header.Get("X-User-ID")
+	req.CallerID = strings.TrimSpace(r.Header.Get("X-User-ID"))
 
 	consent, serviceErr := h.service.UpdateConsent(ctx, req, clientID, orgID, consentID)
 	if serviceErr != nil {
@@ -317,15 +317,11 @@ func (h *consentHandler) revokeConsent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// The header is injected by the gateway/IdP and cannot be spoofed by the
-	// client. Falling back to the JSON body value when the header is absent
-	// would let any caller put an arbitrary userId in the body and bypass the
-	// delegation revocation checks in the service layer.
-	//
-	// If X-User-ID is absent the request has no trusted caller identity.
-	// Clear ActionBy so the service treats this as an anonymous/unauthenticated
-	// call and applies the appropriate default behaviour (non-delegated path).
-	userID := r.Header.Get("X-User-ID")
-	req.ActionBy = userID
+	// client. Always overwrite req.ActionBy with the header value (even if
+	// empty) so the JSON body cannot be used to impersonate a user. When the
+	// header is missing the service will reject the request because ActionBy
+	// is required for delegation policy enforcement.
+	req.ActionBy = strings.TrimSpace(r.Header.Get("X-User-ID"))
 
 	revokeResponse, serviceErr := h.service.RevokeConsent(ctx, consentID, orgID, req)
 	if serviceErr != nil {

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -58,14 +58,11 @@ func (h *consentHandler) createConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set CallerID from X-User-ID header so delegation validation can detect
-	// circular self-delegation (where the delegate being registered is the
-	// same person as the data principal).
-	// This field is NOT read from JSON (tagged json:"-")
+	// Set CallerID from X-User-ID header for delegation validation.
+
 	req.CallerID = strings.TrimSpace(r.Header.Get("X-User-ID"))
 
-	// Propagate the explicitly provided PrincipalID into the attributes map
-	// so that delegation validation and downstream processing can safely use it.
+	// Copy PrincipalID into attributes map for delegation processing.
 	if req.PrincipalID != "" {
 		if req.Attributes == nil {
 			req.Attributes = make(map[string]string)
@@ -85,9 +82,7 @@ func (h *consentHandler) createConsent(w http.ResponseWriter, r *http.Request) {
 		req.Attributes[model.AttrDelegationPrincipalID] = principalID
 	}
 
-	// Validate delegation attributes here in the handler so the check runs even
-	// when the service is mocked in tests. ValidateDelegationAttributes is a no-op
-	// when delegation.type is not present in Attributes.
+	// Validate delegation attributes (no-op when delegation.type is absent).
 	if err := validator.ValidateDelegationAttributes(req.Attributes, req.Authorizations, req.CallerID); err != nil {
 		utils.SendError(w, r, serviceerror.CustomServiceError(ErrorInvalidDelegation, err.Error()))
 		return
@@ -170,14 +165,10 @@ func (h *consentHandler) listConsents(w http.ResponseWriter, r *http.Request) {
 		Offset: offset,
 	}
 
-	// CallerID from X-User-ID header — used to verify the caller is an authorised
-	// delegate when dataPrincipalId is also provided
+	// CallerID from X-User-ID header for delegate authorization.
 	filters.CallerID = strings.TrimSpace(r.Header.Get("X-User-ID"))
 
-	// dataPrincipalId filters consents by data subject (the person whose data was
-	// consented to), not by who gave the consent.
-	// Example: parent logs in → GET /consents?dataPrincipalId=child-user-id
-	// The service checks the caller is a registered delegate before returning results.
+	// dataPrincipalId filters consents by data subject.
 
 	if values, ok := r.URL.Query()["dataPrincipalId"]; ok {
 		dpID := strings.TrimSpace(values[0])

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -70,9 +70,19 @@ func (h *consentHandler) createConsent(w http.ResponseWriter, r *http.Request) {
 		if req.Attributes == nil {
 			req.Attributes = make(map[string]string)
 		}
+		principalID := strings.TrimSpace(req.PrincipalID)
+		// If the caller also set delegation.principal_id directly in attributes,
+		// the two values must agree — reject mismatches rather than silently overwriting.
+		if existing := strings.TrimSpace(req.Attributes[model.AttrDelegationPrincipalID]); existing != "" && existing != principalID {
+			utils.SendError(w, r, serviceerror.CustomServiceError(
+				ErrorInvalidDelegation,
+				"principalId must match attributes.delegation.principal_id",
+			))
+			return
+		}
 		// Uses the canonical constant (e.g. "delegation.principal_id") to ensure the
 		// validator and storage layers interpret the field properly.
-		req.Attributes[model.AttrDelegationPrincipalID] = req.PrincipalID
+		req.Attributes[model.AttrDelegationPrincipalID] = principalID
 	}
 
 	// Validate delegation attributes here in the handler so the check runs even

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -262,6 +262,11 @@ func (h *consentHandler) updateConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Set CallerID from X-User-ID so UpdateConsent can enforce canModify on
+	// delegated consents. The header is injected by the gateway/IdP and cannot
+	// be spoofed by the client.
+	req.CallerID = r.Header.Get("X-User-ID")
+
 	consent, serviceErr := h.service.UpdateConsent(ctx, req, clientID, orgID, consentID)
 	if serviceErr != nil {
 		utils.SendError(w, r, serviceErr)

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -58,8 +58,9 @@ func (h *consentHandler) createConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set CallerID from X-User-ID header so delegation validation in the service
-	// can enforce that a person cannot create a delegated consent for themselves.
+	// Set CallerID from X-User-ID header so delegation validation can detect
+	// circular self-delegation (where the delegate being registered is the
+	// same person as the data principal).
 	// This field is NOT read from JSON (tagged json:"-")
 	req.CallerID = r.Header.Get("X-User-ID")
 

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -179,8 +179,13 @@ func (h *consentHandler) listConsents(w http.ResponseWriter, r *http.Request) {
 	// Example: parent logs in → GET /consents?dataPrincipalId=child-user-id
 	// The service checks the caller is a registered delegate before returning results.
 
-	if dpID := r.URL.Query().Get("dataPrincipalId"); dpID != "" {
-		filters.DataPrincipalID = strings.TrimSpace(dpID)
+	if values, ok := r.URL.Query()["dataPrincipalId"]; ok {
+		dpID := strings.TrimSpace(values[0])
+		if dpID == "" {
+			utils.SendError(w, r, serviceerror.CustomServiceError(ErrorValidationFailed, "dataPrincipalId cannot be blank"))
+			return
+		}
+		filters.DataPrincipalID = dpID
 	}
 
 	// Parse consentTypes (comma-separated)

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -284,14 +284,16 @@ func (h *consentHandler) revokeConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Trusting ActionBy from the request body would allow any caller to put any
-	// userId in the body and bypass the delegation revocation check in the service.
-	// The header is set by the gateway/IdP and cannot be spoofed by the client.
-	// If X-User-ID is absent (non-delegated flows), the body value is kept as-is
-	// so backward compatibility with existing non-delegation revoke flows is preserved.
-	if userID := r.Header.Get("X-User-ID"); userID != "" {
-		req.ActionBy = userID
-	}
+	// The header is injected by the gateway/IdP and cannot be spoofed by the
+	// client. Falling back to the JSON body value when the header is absent
+	// would let any caller put an arbitrary userId in the body and bypass the
+	// delegation revocation checks in the service layer.
+	//
+	// If X-User-ID is absent the request has no trusted caller identity.
+	// Clear ActionBy so the service treats this as an anonymous/unauthenticated
+	// call and applies the appropriate default behaviour (non-delegated path).
+	userID := r.Header.Get("X-User-ID")
+	req.ActionBy = userID
 
 	revokeResponse, serviceErr := h.service.RevokeConsent(ctx, consentID, orgID, req)
 	if serviceErr != nil {

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/wso2/openfgc/internal/consent/model"
+	"github.com/wso2/openfgc/internal/consent/validator"
 	"github.com/wso2/openfgc/internal/system/constants"
 	"github.com/wso2/openfgc/internal/system/error/serviceerror"
 	"github.com/wso2/openfgc/internal/system/utils"
@@ -54,6 +55,19 @@ func (h *consentHandler) createConsent(w http.ResponseWriter, r *http.Request) {
 	var req model.ConsentAPIRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		utils.SendError(w, r, serviceerror.CustomServiceError(ErrorInvalidRequestBody, "Invalid request body"))
+		return
+	}
+
+	// Set CallerID from X-User-ID header so delegation validation in the service
+	// can enforce that a person cannot create a delegated consent for themselves.
+	// This field is NOT read from JSON (tagged json:"-")
+	req.CallerID = r.Header.Get("X-User-ID")
+
+	// Validate delegation attributes here in the handler so the check runs even
+	// when the service is mocked in tests. ValidateDelegationAttributes is a no-op
+	// when delegation.type is not present in Attributes.
+	if err := validator.ValidateDelegationAttributes(req.Attributes, req.Authorizations, req.CallerID); err != nil {
+		utils.SendError(w, r, serviceerror.CustomServiceError(ErrorInvalidDelegation, err.Error()))
 		return
 	}
 
@@ -132,6 +146,19 @@ func (h *consentHandler) listConsents(w http.ResponseWriter, r *http.Request) {
 		OrgID:  orgID,
 		Limit:  limit,
 		Offset: offset,
+	}
+
+	// CallerID from X-User-ID header — used to verify the caller is an authorised
+	// delegate when dataPrincipalId is also provided
+	filters.CallerID = r.Header.Get("X-User-ID")
+
+	// dataPrincipalId filters consents by data subject (the person whose data was
+	// consented to), not by who gave the consent.
+	// Example: parent logs in → GET /consents?dataPrincipalId=child-user-id
+	// The service checks the caller is a registered delegate before returning results.
+
+	if dpID := r.URL.Query().Get("dataPrincipalId"); dpID != "" {
+		filters.DataPrincipalID = strings.TrimSpace(dpID)
 	}
 
 	// Parse consentTypes (comma-separated)
@@ -257,6 +284,15 @@ func (h *consentHandler) revokeConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Trusting ActionBy from the request body would allow any caller to put any
+	// userId in the body and bypass the delegation revocation check in the service.
+	// The header is set by the gateway/IdP and cannot be spoofed by the client.
+	// If X-User-ID is absent (non-delegated flows), the body value is kept as-is
+	// so backward compatibility with existing non-delegation revoke flows is preserved.
+	if userID := r.Header.Get("X-User-ID"); userID != "" {
+		req.ActionBy = userID
+	}
+
 	revokeResponse, serviceErr := h.service.RevokeConsent(ctx, consentID, orgID, req)
 	if serviceErr != nil {
 		utils.SendError(w, r, serviceErr)
@@ -319,6 +355,35 @@ func (h *consentHandler) searchConsentsByAttribute(w http.ResponseWriter, r *htt
 
 	// Call service to search consents by attribute
 	response, serviceErr := h.service.SearchConsentsByAttribute(ctx, key, value, orgID)
+	if serviceErr != nil {
+		utils.SendError(w, r, serviceErr)
+		return
+	}
+
+	w.Header().Set(constants.HeaderContentType, constants.ContentTypeJSON)
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+// getDelegates handles GET /consents/{consentId}/delegates
+// Returns all registered delegates for the given consent, along with delegation
+// metadata (principal_id, revocation policy, expiry).
+func (h *consentHandler) getDelegates(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	consentID := r.PathValue("consentId")
+	orgID := r.Header.Get(constants.HeaderOrgID)
+
+	if err := utils.ValidateOrgID(orgID); err != nil {
+		utils.SendError(w, r, serviceerror.CustomServiceError(ErrorValidationFailed, err.Error()))
+		return
+	}
+
+	if err := utils.ValidateConsentID(consentID); err != nil {
+		utils.SendError(w, r, serviceerror.CustomServiceError(ErrorValidationFailed, err.Error()))
+		return
+	}
+
+	response, serviceErr := h.service.GetConsentDelegates(ctx, consentID, orgID)
 	if serviceErr != nil {
 		utils.SendError(w, r, serviceErr)
 		return

--- a/consent-server/internal/consent/handler_test.go
+++ b/consent-server/internal/consent/handler_test.go
@@ -1012,7 +1012,7 @@ func TestListConsents_UnauthorizedForPrincipal(t *testing.T) {
 				f.CallerID == "some_caller_999"
 		}),
 	).Return(nil, serviceerror.CustomServiceError(
-		ErrorUnauthorized,
+		ErrorNotAuthorizedForPrincipal,
 		"not allowed to access this principal",
 	))
 

--- a/consent-server/internal/consent/handler_test.go
+++ b/consent-server/internal/consent/handler_test.go
@@ -246,6 +246,9 @@ func TestRevokeConsent_Success(t *testing.T) {
 	req.Header.Set(constants.HeaderOrgID, testOrgID)
 	req.Header.Set(constants.HeaderContentType, constants.ContentTypeJSON)
 
+	// Set the header so the handler overwrites ActionBy correctly.
+	req.Header.Set("X-User-ID", "user-123")
+
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -845,13 +848,24 @@ func TestGetDelegates_InvalidConsentID(t *testing.T) {
 	mockService := NewMockConsentService(t)
 	handler := newConsentHandler(mockService)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/consents/not-a-valid-uuid!!/delegates", nil)
+	// Calling handler.getDelegates directly bypasses the router, meaning
+	// PathValue always returns "" and the test passes for the wrong reason
+	// (missing field) instead of exercising the malformed-UUID validation path.
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+constants.APIBasePath+"/consents/{consentId}/delegates", handler.getDelegates)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/consents/not-a-valid-uuid!!/delegates", nil)
+	require.NoError(t, err)
 	req.Header.Set(constants.HeaderOrgID, testOrgID)
-	rr := httptest.NewRecorder()
 
-	handler.getDelegates(rr, req)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
 
-	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func TestGetDelegates_NotFound(t *testing.T) {
@@ -962,15 +976,19 @@ func TestListConsents_WithDataPrincipalID(t *testing.T) {
 		},
 	}
 
-	// Verify that dataPrincipalId query param flows into ConsentSearchFilters.DataPrincipalID
+	// to ConsentSearchFilters.CallerID so the delegation authorization path
+	// is exercised (X-User-ID is required for dataPrincipalId queries).
 	mockService.On("SearchConsentsDetailed", mock.Anything,
 		mock.MatchedBy(func(f model.ConsentSearchFilters) bool {
-			return f.DataPrincipalID == "child_user_123" && f.OrgID == testOrgID
+			return f.DataPrincipalID == "child_user_123" &&
+				f.OrgID == testOrgID &&
+				f.CallerID == "parent_user_456"
 		}),
 	).Return(expectedResponse, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/consents?dataPrincipalId=child_user_123", nil)
 	req.Header.Set(constants.HeaderOrgID, testOrgID)
+	req.Header.Set("X-User-ID", "parent_user_456")
 	rr := httptest.NewRecorder()
 
 	handler.listConsents(rr, req)
@@ -986,9 +1004,12 @@ func TestListConsents_UnauthorizedForPrincipal(t *testing.T) {
 	handler := newConsentHandler(mockService)
 
 	// Simulate unauthorized access error from service layer
+	// service-layer authorization check is properly exercised.
 	mockService.On("SearchConsentsDetailed", mock.Anything,
 		mock.MatchedBy(func(f model.ConsentSearchFilters) bool {
-			return f.DataPrincipalID == "unauthorized_user" && f.OrgID == testOrgID
+			return f.DataPrincipalID == "unauthorized_user" &&
+				f.OrgID == testOrgID &&
+				f.CallerID == "some_caller_999"
 		}),
 	).Return(nil, serviceerror.CustomServiceError(
 		ErrorUnauthorized,
@@ -997,6 +1018,7 @@ func TestListConsents_UnauthorizedForPrincipal(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/consents?dataPrincipalId=unauthorized_user", nil)
 	req.Header.Set(constants.HeaderOrgID, testOrgID)
+	req.Header.Set("X-User-ID", "some_caller_999")
 	rr := httptest.NewRecorder()
 
 	handler.listConsents(rr, req)

--- a/consent-server/internal/consent/handler_test.go
+++ b/consent-server/internal/consent/handler_test.go
@@ -217,7 +217,15 @@ func TestListConsents_Success(t *testing.T) {
 func TestRevokeConsent_Success(t *testing.T) {
 	mockService := NewMockConsentService(t)
 
-	revokeRequest := model.ConsentRevokeRequest{
+	// Body sends a DIFFERENT ActionBy than the header to prove the handler
+	// overwrites the JSON body value with the trusted X-User-ID header.
+	bodyRequest := model.ConsentRevokeRequest{
+		ActionBy:         "body-user-should-be-overwritten",
+		RevocationReason: "User requested revocation",
+	}
+
+	// The service must receive the header value, not the body value.
+	expectedServiceRequest := model.ConsentRevokeRequest{
 		ActionBy:         "user-123",
 		RevocationReason: "User requested revocation",
 	}
@@ -228,7 +236,7 @@ func TestRevokeConsent_Success(t *testing.T) {
 		RevocationReason: "User requested revocation",
 	}
 
-	mockService.On("RevokeConsent", mock.Anything, "550e8400-e29b-41d4-a716-446655440000", testOrgID, revokeRequest).
+	mockService.On("RevokeConsent", mock.Anything, "550e8400-e29b-41d4-a716-446655440000", testOrgID, expectedServiceRequest).
 		Return(expectedResponse, nil)
 
 	handler := newConsentHandler(mockService)
@@ -238,7 +246,7 @@ func TestRevokeConsent_Success(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	body, err := json.Marshal(revokeRequest)
+	body, err := json.Marshal(bodyRequest)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPut, server.URL+"/api/v1/consents/550e8400-e29b-41d4-a716-446655440000/revoke", bytes.NewBuffer(body))

--- a/consent-server/internal/consent/handler_test.go
+++ b/consent-server/internal/consent/handler_test.go
@@ -810,7 +810,7 @@ func TestGetDelegates_Success(t *testing.T) {
 		},
 	}
 
-	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID).
+	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID, "parent_mom_456").
 		Return(expectedResponse, nil)
 
 	mux := http.NewServeMux()
@@ -822,6 +822,7 @@ func TestGetDelegates_Success(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/consents/"+consentID+"/delegates", nil)
 	require.NoError(t, err)
 	req.Header.Set(constants.HeaderOrgID, testOrgID)
+	req.Header.Set("X-User-ID", "parent_mom_456")
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -882,7 +883,7 @@ func TestGetDelegates_NotFound(t *testing.T) {
 
 	consentID := "550e8400-e29b-41d4-a716-446655440001"
 
-	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID).
+	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID, "caller-user-001").
 		Return(nil, serviceerror.CustomServiceError(ErrorConsentNotFound, "Consent not found"))
 
 	mux := http.NewServeMux()
@@ -894,6 +895,7 @@ func TestGetDelegates_NotFound(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/consents/"+consentID+"/delegates", nil)
 	require.NoError(t, err)
 	req.Header.Set(constants.HeaderOrgID, testOrgID)
+	req.Header.Set("X-User-ID", "caller-user-001")
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -909,7 +911,7 @@ func TestGetDelegates_ServiceError(t *testing.T) {
 
 	consentID := "550e8400-e29b-41d4-a716-446655440002"
 
-	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID).
+	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID, "caller-user-001").
 		Return(nil, serviceerror.CustomServiceError(ErrorInternalServerError, "database error"))
 
 	mux := http.NewServeMux()
@@ -921,6 +923,7 @@ func TestGetDelegates_ServiceError(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/consents/"+consentID+"/delegates", nil)
 	require.NoError(t, err)
 	req.Header.Set(constants.HeaderOrgID, testOrgID)
+	req.Header.Set("X-User-ID", "caller-user-001")
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -941,7 +944,7 @@ func TestGetDelegates_NoDelegates(t *testing.T) {
 		Delegates:     []model.DelegateInfo{},
 	}
 
-	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID).
+	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID, "caller-user-001").
 		Return(expectedResponse, nil)
 
 	mux := http.NewServeMux()
@@ -953,6 +956,7 @@ func TestGetDelegates_NoDelegates(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/consents/"+consentID+"/delegates", nil)
 	require.NoError(t, err)
 	req.Header.Set(constants.HeaderOrgID, testOrgID)
+	req.Header.Set("X-User-ID", "caller-user-001")
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -966,6 +970,30 @@ func TestGetDelegates_NoDelegates(t *testing.T) {
 	require.Equal(t, 0, response.DelegateCount)
 	require.Empty(t, response.Delegates)
 	mockService.AssertExpectations(t)
+}
+
+func TestGetDelegates_MissingUserID(t *testing.T) {
+	mockService := NewMockConsentService(t)
+	handler := newConsentHandler(mockService)
+
+	consentID := "550e8400-e29b-41d4-a716-446655440000"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+constants.APIBasePath+"/consents/{consentId}/delegates", handler.getDelegates)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// No X-User-ID header — must be rejected before reaching the service
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/consents/"+consentID+"/delegates", nil)
+	require.NoError(t, err)
+	req.Header.Set(constants.HeaderOrgID, testOrgID)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
 // ── GET /consents?dataPrincipalId= ───────────────────────────────────────────

--- a/consent-server/internal/consent/handler_test.go
+++ b/consent-server/internal/consent/handler_test.go
@@ -762,3 +762,288 @@ func TestSearchConsentsByAttribute_MissingOrgID(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
+
+// ── GET /consents/{consentId}/delegates ──────────────────────────────────────
+
+func TestGetDelegates_Success(t *testing.T) {
+	mockService := NewMockConsentService(t)
+	handler := newConsentHandler(mockService)
+
+	consentID := "550e8400-e29b-41d4-a716-446655440000"
+	expectedResponse := &model.DelegateListResponse{
+		ConsentID:        consentID,
+		DataPrincipalID:  "child_user_123",
+		RevocationPolicy: "ANY",
+		DelegateCount:    2,
+		Delegates: []model.DelegateInfo{
+			{
+				AuthID:         "auth-001",
+				UserID:         "parent_mom_456",
+				DelegationType: "parental_biological",
+				Status:         "approved",
+				CanRevoke:      true,
+				CanModify:      true,
+				OnBehalfOf:     "child_user_123",
+				UpdatedTime:    1700000000000,
+			},
+			{
+				AuthID:         "auth-002",
+				UserID:         "parent_dad_789",
+				DelegationType: "parental_biological",
+				Status:         "approved",
+				CanRevoke:      true,
+				CanModify:      true,
+				OnBehalfOf:     "child_user_123",
+				UpdatedTime:    1700000000000,
+			},
+		},
+	}
+
+	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID).
+		Return(expectedResponse, nil)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+constants.APIBasePath+"/consents/{consentId}/delegates", handler.getDelegates)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/consents/"+consentID+"/delegates", nil)
+	require.NoError(t, err)
+	req.Header.Set(constants.HeaderOrgID, testOrgID)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var response model.DelegateListResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	require.NoError(t, err)
+	require.Equal(t, consentID, response.ConsentID)
+	require.Equal(t, 2, response.DelegateCount)
+	require.Equal(t, "child_user_123", response.DataPrincipalID)
+	require.Equal(t, "ANY", response.RevocationPolicy)
+	mockService.AssertExpectations(t)
+}
+
+func TestGetDelegates_MissingOrgID(t *testing.T) {
+	mockService := NewMockConsentService(t)
+	handler := newConsentHandler(mockService)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/consents/550e8400-e29b-41d4-a716-446655440000/delegates", nil)
+	// No org-id header
+	rr := httptest.NewRecorder()
+
+	handler.getDelegates(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetDelegates_InvalidConsentID(t *testing.T) {
+	mockService := NewMockConsentService(t)
+	handler := newConsentHandler(mockService)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/consents/not-a-valid-uuid!!/delegates", nil)
+	req.Header.Set(constants.HeaderOrgID, testOrgID)
+	rr := httptest.NewRecorder()
+
+	handler.getDelegates(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetDelegates_NotFound(t *testing.T) {
+	mockService := NewMockConsentService(t)
+	handler := newConsentHandler(mockService)
+
+	consentID := "550e8400-e29b-41d4-a716-446655440001"
+
+	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID).
+		Return(nil, serviceerror.CustomServiceError(ErrorConsentNotFound, "Consent not found"))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+constants.APIBasePath+"/consents/{consentId}/delegates", handler.getDelegates)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/consents/"+consentID+"/delegates", nil)
+	require.NoError(t, err)
+	req.Header.Set(constants.HeaderOrgID, testOrgID)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	mockService.AssertExpectations(t)
+}
+
+func TestGetDelegates_ServiceError(t *testing.T) {
+	mockService := NewMockConsentService(t)
+	handler := newConsentHandler(mockService)
+
+	consentID := "550e8400-e29b-41d4-a716-446655440002"
+
+	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID).
+		Return(nil, serviceerror.CustomServiceError(ErrorInternalServerError, "database error"))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+constants.APIBasePath+"/consents/{consentId}/delegates", handler.getDelegates)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/consents/"+consentID+"/delegates", nil)
+	require.NoError(t, err)
+	req.Header.Set(constants.HeaderOrgID, testOrgID)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	mockService.AssertExpectations(t)
+}
+
+func TestGetDelegates_NoDelegates(t *testing.T) {
+	mockService := NewMockConsentService(t)
+	handler := newConsentHandler(mockService)
+
+	consentID := "550e8400-e29b-41d4-a716-446655440003"
+	expectedResponse := &model.DelegateListResponse{
+		ConsentID:     consentID,
+		DelegateCount: 0,
+		Delegates:     []model.DelegateInfo{},
+	}
+
+	mockService.On("GetConsentDelegates", mock.Anything, consentID, testOrgID).
+		Return(expectedResponse, nil)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+constants.APIBasePath+"/consents/{consentId}/delegates", handler.getDelegates)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/consents/"+consentID+"/delegates", nil)
+	require.NoError(t, err)
+	req.Header.Set(constants.HeaderOrgID, testOrgID)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var response model.DelegateListResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	require.NoError(t, err)
+	require.Equal(t, 0, response.DelegateCount)
+	require.Empty(t, response.Delegates)
+	mockService.AssertExpectations(t)
+}
+
+// ── GET /consents?dataPrincipalId= ───────────────────────────────────────────
+
+func TestListConsents_WithDataPrincipalID(t *testing.T) {
+	mockService := NewMockConsentService(t)
+	handler := newConsentHandler(mockService)
+
+	expectedResponse := &model.ConsentDetailSearchResponse{
+		Data: []model.ConsentDetailResponse{},
+		Metadata: model.ConsentSearchMetadata{
+			Total:  0,
+			Limit:  10,
+			Offset: 0,
+			Count:  0,
+		},
+	}
+
+	// Verify that dataPrincipalId query param flows into ConsentSearchFilters.DataPrincipalID
+	mockService.On("SearchConsentsDetailed", mock.Anything,
+		mock.MatchedBy(func(f model.ConsentSearchFilters) bool {
+			return f.DataPrincipalID == "child_user_123" && f.OrgID == testOrgID
+		}),
+	).Return(expectedResponse, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/consents?dataPrincipalId=child_user_123", nil)
+	req.Header.Set(constants.HeaderOrgID, testOrgID)
+	rr := httptest.NewRecorder()
+
+	handler.listConsents(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	mockService.AssertExpectations(t)
+}
+
+// GET /consents?dataPrincipalId=X without being a delegate → 403
+
+func TestListConsents_UnauthorizedForPrincipal(t *testing.T) {
+	mockService := NewMockConsentService(t)
+	handler := newConsentHandler(mockService)
+
+	// Simulate unauthorized access error from service layer
+	mockService.On("SearchConsentsDetailed", mock.Anything,
+		mock.MatchedBy(func(f model.ConsentSearchFilters) bool {
+			return f.DataPrincipalID == "unauthorized_user" && f.OrgID == testOrgID
+		}),
+	).Return(nil, serviceerror.CustomServiceError(
+		ErrorUnauthorized,
+		"not allowed to access this principal",
+	))
+
+	req := httptest.NewRequest(http.MethodGet, "/consents?dataPrincipalId=unauthorized_user", nil)
+	req.Header.Set(constants.HeaderOrgID, testOrgID)
+	rr := httptest.NewRecorder()
+
+	handler.listConsents(rr, req)
+
+	require.Equal(t, http.StatusForbidden, rr.Code)
+	mockService.AssertExpectations(t)
+}
+
+// — POST /consents with delegation.type but no principal_id → 400
+
+func TestCreateConsent_InvalidDelegationAttributes(t *testing.T) {
+	mockService := NewMockConsentService(t)
+	handler := newConsentHandler(mockService)
+
+	// ValidateDelegationAttributes checks req.Attributes["delegation.type"].
+	// When delegation.type is set but delegation.principal_id is missing,
+	// the validator rejects the request before CreateConsent is ever called —
+	// so no Mock.On("CreateConsent") is needed here.
+	request := model.ConsentAPIRequest{
+		Type: "accounts",
+		// delegation.type is set → triggers ValidateDelegationAttributes
+		// delegation.principal_id is intentionally absent → Rule 1 rejects the request
+		Attributes: map[string]string{
+			"delegation.type": "guardian",
+			// "delegation.principal_id" deliberately omitted
+		},
+		Purposes: []model.ConsentPurposeItem{
+			{
+				PurposeName: "purpose-1",
+				Elements: []model.ConsentElementApprovalItem{
+					{ElementName: "element-1", IsUserApproved: true},
+				},
+			},
+		},
+		Authorizations: []model.AuthorizationAPIRequest{
+			{Type: "accounts"},
+		},
+	}
+
+	body, _ := json.Marshal(request)
+	req := httptest.NewRequest(http.MethodPost, "/consents", bytes.NewBuffer(body))
+	req.Header.Set(constants.HeaderOrgID, testOrgID)
+	req.Header.Set(constants.HeaderTPPClientID, testClientID)
+	rr := httptest.NewRecorder()
+
+	handler.createConsent(rr, req)
+
+	// Expect 400 Bad Request — delegation.principal_id missing (Rule 1 of ValidateDelegationAttributes)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/consent-server/internal/consent/handler_test.go
+++ b/consent-server/internal/consent/handler_test.go
@@ -869,6 +869,7 @@ func TestGetDelegates_InvalidConsentID(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/consents/not-a-valid-uuid!!/delegates", nil)
 	require.NoError(t, err)
 	req.Header.Set(constants.HeaderOrgID, testOrgID)
+	req.Header.Set("X-User-ID", "caller-user-001")
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)

--- a/consent-server/internal/consent/init.go
+++ b/consent-server/internal/consent/init.go
@@ -59,4 +59,7 @@ func registerRoutes(mux *http.ServeMux, handler *consentHandler) {
 
 	// GET /api/v1/consents/attributes - Search consents by attribute
 	mux.HandleFunc("GET "+constants.APIBasePath+"/consents/attributes", handler.searchConsentsByAttribute)
+
+	// GET /api/v1/consents/{consentId}/delegates - Get consent delegates
+	mux.HandleFunc("GET "+constants.APIBasePath+"/consents/{consentId}/delegates", handler.getDelegates)
 }

--- a/consent-server/internal/consent/model/consent.go
+++ b/consent-server/internal/consent/model/consent.go
@@ -59,6 +59,8 @@ const (
 	RevocationPolicyAny RevocationPolicy = "ANY"
 	// RevocationPolicySubjectOnly allows only the data principal to revoke.
 	RevocationPolicySubjectOnly RevocationPolicy = "SUBJECT_ONLY"
+	// RevocationPolicyBoth allows both the data principal and authorized delegates to revoke.
+	RevocationPolicyBoth RevocationPolicy = "BOTH"
 )
 
 // DelegationConfig is a parsed view of the delegation CONSENT_ATTRIBUTE rows.

--- a/consent-server/internal/consent/model/consent.go
+++ b/consent-server/internal/consent/model/consent.go
@@ -83,7 +83,7 @@ func (d DelegationConfig) IsExpired() bool {
 	if d.ValidUntil == 0 {
 		return false
 	}
-	return time.Now().Unix() > d.ValidUntil
+	return time.Now().Unix() >= d.ValidUntil
 }
 
 // ─── end delegation support ───────────────────────────────────────────────────
@@ -553,18 +553,28 @@ type ConsentSearchMetadata struct {
 
 // ConsentSearchFilters represents search criteria for consents
 type ConsentSearchFilters struct {
-	ConsentTypes         []string // e.g., ["accounts", "payments"]
-	ConsentStatuses      []string // e.g., ["active", "revoked"]
-	ClientIDs            []string // TPP client IDs
-	UserIDs              []string // End-user IDs
-	PurposeNames         []string // Purpose names - returns consents containing ANY of these purposes
-	FromTime             *int64   // Unix timestamp - start of time window
-	ToTime               *int64   // Unix timestamp - end of time window
-	Limit                int
-	Offset               int
-	OrgID                string
-	DataPrincipalID      string
-	CallerID             string
+	ConsentTypes    []string // e.g., ["accounts", "payments"]
+	ConsentStatuses []string // e.g., ["active", "revoked"]
+	ClientIDs       []string // TPP client IDs
+	UserIDs         []string // End-user IDs
+	PurposeNames    []string // Purpose names - returns consents containing ANY of these purposes
+	FromTime        *int64   // Unix timestamp - start of time window
+	ToTime          *int64   // Unix timestamp - end of time window
+	Limit           int
+	Offset          int
+	OrgID           string
+	// DataPrincipalID filters consents by the data subject stored in
+	// CONSENT_ATTRIBUTE (key = delegation.principal_id).
+	// Use this when a parent/guardian wants to see consents for their child.
+	// The service will verify CallerID is an authorised delegate.
+	DataPrincipalID string
+	// CallerID is the authenticated user making the list request.
+	// Required when DataPrincipalID is set so the service can verify
+	// the caller is an authorised delegate before returning results.
+	CallerID string
+	// AuthorizedConsentIDs is a list of consent IDs that the caller is explicitly
+	// authorized to see. If non-nil, the DB search will be restricted to ONLY these IDs.
+	// This ensures pagination limits and offsets are applied accurately by the database.
 	AuthorizedConsentIDs []string
 }
 
@@ -588,7 +598,7 @@ type ConsentDetailResponse struct {
 	// prompt them to review and re-confirm or revoke inherited consents.
 	// Uses the same wire name as DelegateListResponse so clients see one
 	// canonical field name for this concept across all consent endpoints.
-	IsDelegationExpired bool `json:"isDelegationExpired,omitempty"`
+	IsDelegationExpired bool `json:"isDelegationExpired"`
 }
 
 // AuthorizationDetail represents authorization resource details

--- a/consent-server/internal/consent/model/consent.go
+++ b/consent-server/internal/consent/model/consent.go
@@ -285,6 +285,49 @@ type DelegationAPIRequest struct {
 	CanModify bool `json:"canModify,omitempty"`
 }
 
+// mergeDelegationIntoResources merges the Delegation fields into the Resources map
+// so they are persisted in the RESOURCES JSON blob of CONSENT_AUTH_RESOURCE.
+// When Delegation is nil or Resources already contains onBehalfOf, the input is
+// returned unchanged. This is the single place where delegation metadata is
+// serialized — no DB schema change required.
+func mergeDelegationIntoResources(resources interface{}, delegation *DelegationAPIRequest) interface{} {
+	if delegation == nil {
+		return resources
+	}
+
+	// Start with an empty map or a copy of the existing resources map.
+	merged := make(map[string]interface{})
+	if resources != nil {
+		// resources may already be a map (from JSON decode) or a raw JSON []byte.
+		switch v := resources.(type) {
+		case map[string]interface{}:
+			for k, val := range v {
+				merged[k] = val
+			}
+		default:
+			// Fallback: round-trip through JSON to get a generic map.
+			b, err := json.Marshal(resources)
+			if err == nil {
+				_ = json.Unmarshal(b, &merged)
+			}
+		}
+	}
+
+	// Write delegation fields into the map.
+	// onBehalfOf is the key the service layer reads to identify delegate rows.
+	if delegation.PrincipalID != "" {
+		merged["onBehalfOf"] = delegation.PrincipalID
+	}
+	if delegation.Type != "" {
+		merged["delegationType"] = delegation.Type
+	}
+	// Always write bool flags so false is explicit (not missing).
+	merged["canRevoke"] = delegation.CanRevoke
+	merged["canModify"] = delegation.CanModify
+
+	return merged
+}
+
 // DelegateInfo represents a single registered delegate on a consent.
 // Assembled at read time from a CONSENT_AUTH_RESOURCE row and its RESOURCES blob.
 type DelegateInfo struct {
@@ -613,11 +656,14 @@ func (req *ConsentAPIRequest) ToConsentCreateRequest() (*ConsentCreateRequest, e
 				status = string(AuthStatusMappings.ApprovedState)
 			}
 
+			// persisting, so onBehalfOf/canRevoke/canModify/delegationType are
+			// stored in the RESOURCES blob and readable by the delegates endpoint.
+			resources := mergeDelegationIntoResources(auth.Resources, auth.Delegation)
 			createReq.AuthResources[i] = authmodel.ConsentAuthResourceCreateRequest{
 				AuthType:   auth.Type,
 				UserID:     userID,
 				AuthStatus: status,
-				Resources:  auth.Resources,
+				Resources:  resources,
 			}
 		}
 	}
@@ -695,11 +741,13 @@ func (req *ConsentAPIUpdateRequest) ToConsentUpdateRequest() (*ConsentUpdateRequ
 				status = string(AuthStatusMappings.ApprovedState)
 			}
 
+			// fields must be written into the RESOURCES blob on update too.
+			resources := mergeDelegationIntoResources(auth.Resources, auth.Delegation)
 			updateReq.AuthResources[i] = authmodel.ConsentAuthResourceCreateRequest{
 				AuthType:   auth.Type,
 				UserID:     userID,
 				AuthStatus: status, // Store the status value
-				Resources:  auth.Resources,
+				Resources:  resources,
 			}
 		}
 	}

--- a/consent-server/internal/consent/model/consent.go
+++ b/consent-server/internal/consent/model/consent.go
@@ -28,26 +28,11 @@ import (
 	"github.com/wso2/openfgc/internal/system/config"
 )
 
-// ─── Delegation support ───────────────────────────────────────────────────────
-// All delegation data is stored in the existing CONSENT_ATTRIBUTE table as
-
-// Attribute key constants for delegation metadata stored in CONSENT_ATTRIBUTE.
+// Delegation attribute keys stored in CONSENT_ATTRIBUTE table.
 const (
-	// AttrDelegationType is the kind of delegation.
-	// Examples: "parental_biological", "parental_legal", "guardian", "carer", "power_of_attorney"
-	AttrDelegationType = "delegation.type"
-
-	// AttrDelegationPrincipalID is the userId of the actual data subject
-	// (the person WHOSE data is being processed, not the person giving consent).
-	AttrDelegationPrincipalID = "delegation.principal_id"
-
-	// AttrGuardianValidUntil is the Unix timestamp (seconds) after which the
-	// delegation expires. For minors, set this to the child's 18th birthday.
-	// After this point only the principal may act on the consent.
-	AttrGuardianValidUntil = "guardian.valid_until"
-
-	// AttrGuardianRevocationPolicy controls who may revoke a delegated consent.
-	// Use RevocationPolicyAny or RevocationPolicySubjectOnly below.
+	AttrDelegationType           = "delegation.type"
+	AttrDelegationPrincipalID    = "delegation.principal_id"
+	AttrGuardianValidUntil       = "guardian.valid_until"
 	AttrGuardianRevocationPolicy = "guardian.revocation_policy"
 )
 
@@ -55,16 +40,12 @@ const (
 type RevocationPolicy string
 
 const (
-	// RevocationPolicyAny allows any registered delegate with canRevoke=true to revoke.
-	RevocationPolicyAny RevocationPolicy = "ANY"
-	// RevocationPolicySubjectOnly allows only the data principal to revoke.
-	RevocationPolicySubjectOnly RevocationPolicy = "SUBJECT_ONLY"
-	// RevocationPolicyBoth allows both the data principal and authorized delegates to revoke.
-	RevocationPolicyBoth RevocationPolicy = "BOTH"
+	RevocationPolicyAny         RevocationPolicy = "ANY"          // Only delegates with canRevoke=true
+	RevocationPolicySubjectOnly RevocationPolicy = "SUBJECT_ONLY" // Only the data principal
+	RevocationPolicyBoth        RevocationPolicy = "BOTH"         // Both principal and delegates
 )
 
-// DelegationConfig is a parsed view of the delegation CONSENT_ATTRIBUTE rows.
-// Built at runtime from the attribute map — not stored as a separate struct.
+// DelegationConfig is parsed from CONSENT_ATTRIBUTE rows at runtime.
 type DelegationConfig struct {
 	Type             string
 	PrincipalID      string
@@ -72,21 +53,18 @@ type DelegationConfig struct {
 	RevocationPolicy RevocationPolicy
 }
 
-// IsGuardianConsent returns true when this consent was given on behalf of someone else.
+// IsGuardianConsent returns true when delegation.type is set.
 func (d DelegationConfig) IsGuardianConsent() bool {
 	return d.Type != ""
 }
 
-// IsExpired returns true when the delegation period has ended.
-// When true, only the data principal may act on the consent.
+// IsExpired returns true when the current time is past guardian.valid_until.
 func (d DelegationConfig) IsExpired() bool {
 	if d.ValidUntil == 0 {
 		return false
 	}
 	return time.Now().Unix() >= d.ValidUntil
 }
-
-// ─── end delegation support ───────────────────────────────────────────────────
 
 // Consent represents the CONSENT table
 type Consent struct {
@@ -254,52 +232,27 @@ type ConsentAPIRequest struct {
 	DataAccessValidityDuration *int64                    `json:"dataAccessValidityDuration,omitempty"`
 	Purposes                   []ConsentPurposeItem      `json:"purposes" binding:"required,min=1"`
 	Attributes                 map[string]string         `json:"attributes,omitempty"`
-	Authorizations             []AuthorizationAPIRequest `json:"authorizations"` // Remove omitempty to allow explicit empty array in updates
-	// CallerID is set by the handler from the X-User-ID request header.
-	// It is NOT read from the JSON body (json:"-").
-	// Used by delegation validation to ensure the consent initiator is not
-	// also the data principal — cannot self-delegate
-	CallerID string `json:"-"`
-	// PrincipalID is the userId of the data subject when this consent is being
-	// given on behalf of another person (e.g., parent creating consent for child).
-	// It mirrors the delegation.principal_id attribute stored in CONSENT_ATTRIBUTE.
-	// Provided as a convenience field on the request for validation.
-	PrincipalID string `json:"principalId,omitempty"`
+	Authorizations             []AuthorizationAPIRequest `json:"authorizations"`        // Remove omitempty to allow explicit empty array in updates
+	CallerID                   string                    `json:"-"`                     // Set from X-User-ID header, not from JSON body
+	PrincipalID                string                    `json:"principalId,omitempty"` // Convenience field — copied to attributes["delegation.principal_id"] by handler
 }
 
-// ─── Delegation response types ────────────────────────────────────────────────
-// These types support the GET /consents/{consentId}/delegates endpoint and
-// the delegate-related test assertions.
-
-// DelegationAPIRequest carries optional delegation metadata on an authorization
-// resource at consent creation time. It is used when the consent is being given
-// on behalf of another person (e.g., parent for child). Stored in the RESOURCES
-// JSON blob of CONSENT_AUTH_RESOURCE — no schema change needed.
+// DelegationAPIRequest carries delegation metadata on an authorization resource.
+// Merged into the RESOURCES JSON blob of CONSENT_AUTH_RESOURCE.
 type DelegationAPIRequest struct {
-	// Type is the delegation relationship, e.g. "parental_biological", "carer".
-	Type string `json:"type,omitempty"`
-	// PrincipalID is the userId of the actual data subject (the person whose data
-	// is being processed). Must match delegation.principal_id in CONSENT_ATTRIBUTE.
+	Type        string `json:"type,omitempty"`
 	PrincipalID string `json:"principalId,omitempty"`
-	// CanRevoke indicates whether this delegate may revoke the consent.
-	CanRevoke bool `json:"canRevoke,omitempty"`
-	// CanModify indicates whether this delegate may modify the consent.
-	CanModify bool `json:"canModify,omitempty"`
+	CanRevoke   bool   `json:"canRevoke,omitempty"`
+	CanModify   bool   `json:"canModify,omitempty"`
 }
 
-// mergeDelegationIntoResources merges the Delegation fields into the Resources map
-// so they are persisted in the RESOURCES JSON blob of CONSENT_AUTH_RESOURCE.
-// When Delegation is nil the input is returned unchanged.
-//
-// Returns an error when resources is a non-object type (array, string, scalar)
-// so the caller knows the payload is incompatible and the original data is not
-// silently lost.
+// mergeDelegationIntoResources merges Delegation fields into the Resources map.
+// Returns an error when resources is a non-object type.
 func mergeDelegationIntoResources(resources interface{}, delegation *DelegationAPIRequest) (interface{}, error) {
 	if delegation == nil {
 		return resources, nil
 	}
 
-	// Start with an empty map or a copy of the existing resources map.
 	merged := make(map[string]interface{})
 	if resources != nil {
 		switch v := resources.(type) {
@@ -308,9 +261,6 @@ func mergeDelegationIntoResources(resources interface{}, delegation *DelegationA
 				merged[k] = val
 			}
 		default:
-			// Fallback: round-trip through JSON.
-			// If the value is not a JSON object (e.g. array, string, number) we
-			// return an explicit error instead of silently dropping data.
 			b, err := json.Marshal(resources)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal resources for delegation merge: %w", err)
@@ -330,79 +280,52 @@ func mergeDelegationIntoResources(resources interface{}, delegation *DelegationA
 		}
 	}
 
-	// Write delegation fields into the map.
-	// onBehalfOf is the key the service layer reads to identify delegate rows.
 	if delegation.PrincipalID != "" {
 		merged["onBehalfOf"] = delegation.PrincipalID
 	}
 	if delegation.Type != "" {
 		merged["delegationType"] = delegation.Type
 	}
-	// Always write bool flags so false is explicit (not missing).
 	merged["canRevoke"] = delegation.CanRevoke
 	merged["canModify"] = delegation.CanModify
 
 	return merged, nil
 }
 
-// DelegateInfo represents a single registered delegate on a consent.
-// Assembled at read time from a CONSENT_AUTH_RESOURCE row and its RESOURCES blob.
+// DelegateInfo represents a single delegate from CONSENT_AUTH_RESOURCE.
 type DelegateInfo struct {
-	// AuthID is the CONSENT_AUTH_RESOURCE.AUTH_ID for this delegate row.
-	AuthID string `json:"authId"`
-	// UserID is the delegate's userId (e.g., the parent's account ID).
-	UserID string `json:"userId"`
-	// DelegationType mirrors the delegation.type value (e.g., "parental_biological").
+	AuthID         string `json:"authId"`
+	UserID         string `json:"userId"`
 	DelegationType string `json:"delegationType,omitempty"`
-	// Status is the CONSENT_AUTH_RESOURCE.AUTH_STATUS (e.g., "approved").
-	Status string `json:"status"`
-	// CanRevoke is true when this delegate may revoke the consent.
-	CanRevoke bool `json:"canRevoke"`
-	// CanModify is true when this delegate may modify the consent.
-	CanModify bool `json:"canModify"`
-	// OnBehalfOf is the principalID this delegate is acting for.
-	OnBehalfOf string `json:"onBehalfOf,omitempty"`
-	// UpdatedTime is the CONSENT_AUTH_RESOURCE.UPDATED_TIME in milliseconds.
-	UpdatedTime int64 `json:"updatedTime"`
+	Status         string `json:"status"`
+	CanRevoke      bool   `json:"canRevoke"`
+	CanModify      bool   `json:"canModify"`
+	OnBehalfOf     string `json:"onBehalfOf,omitempty"`
+	UpdatedTime    int64  `json:"updatedTime"`
 }
 
-// DelegateListResponse is the response body for GET /consents/{consentId}/delegates.
-// It aggregates all delegate auth resources for a single consent.
+// DelegateListResponse is the response for GET /consents/{consentId}/delegates.
 type DelegateListResponse struct {
-	// ConsentID is the consent this response belongs to.
-	ConsentID string `json:"consentId"`
-	// DataPrincipalID is the userId of the data subject (from delegation.principal_id).
-	DataPrincipalID string `json:"dataPrincipalId,omitempty"`
-	// RevocationPolicy mirrors guardian.revocation_policy (e.g., "ANY").
-	RevocationPolicy string `json:"revocationPolicy,omitempty"`
-	// ValidUntil is the delegation expiry Unix timestamp (from guardian.valid_until).
-	ValidUntil int64 `json:"validUntil,omitempty"`
-	// IsDelegationExpired is true when the current time is past ValidUntil.
-	IsDelegationExpired bool `json:"isDelegationExpired"`
-	// DelegateCount is the total number of delegates registered on this consent.
-	DelegateCount int `json:"delegateCount"`
-	// Delegates is the list of individual delegate records.
-	Delegates []DelegateInfo `json:"delegates"`
+	ConsentID           string         `json:"consentId"`
+	DataPrincipalID     string         `json:"dataPrincipalId,omitempty"`
+	RevocationPolicy    string         `json:"revocationPolicy,omitempty"`
+	ValidUntil          int64          `json:"validUntil,omitempty"`
+	IsDelegationExpired bool           `json:"isDelegationExpired"`
+	DelegateCount       int            `json:"delegateCount"`
+	Delegates           []DelegateInfo `json:"delegates"`
 }
-
-// ─── end delegation response types ───────────────────────────────────────────
 
 // AuthorizationAPIRequest represents the API payload for authorization resource (external format)
 // Status field represents the authorization status/state (created, approved, rejected, or custom)
 type AuthorizationAPIRequest struct {
-	UserID    string      `json:"userId,omitempty"`
-	Type      string      `json:"type" binding:"required"`
-	Status    string      `json:"status,omitempty"` // Optional: defaults to "approved" if not provided
-	Resources interface{} `json:"resources,omitempty"`
-	// Delegation carries optional delegation metadata when this authorization represents
-	// a delegate acting on behalf of a data principal. Stored inside the RESOURCES JSON blob.
-	// Not a separate DB column — no schema change required.
-	Delegation *DelegationAPIRequest `json:"delegation,omitempty"`
+	UserID     string                `json:"userId,omitempty"`
+	Type       string                `json:"type" binding:"required"`
+	Status     string                `json:"status,omitempty"` // Optional: defaults to "approved" if not provided
+	Resources  interface{}           `json:"resources,omitempty"`
+	Delegation *DelegationAPIRequest `json:"delegation,omitempty"` // Merged into RESOURCES JSON blob
 }
 
 // ToAuthResourceCreateRequest converts API request format to internal format.
-// Returns an error when delegation fields cannot be merged into resources
-// (e.g. when resources is a non-object JSON value such as an array or string).
 func (req *AuthorizationAPIRequest) ToAuthResourceCreateRequest() (*authmodel.ConsentAuthResourceCreateRequest, error) {
 
 	AuthStatusMappings := config.Get().Consent.AuthStatusMappings
@@ -469,14 +392,8 @@ type ConsentAPIUpdateRequest struct {
 	Purposes                   []ConsentPurposeItem      `json:"purposes"`
 	Attributes                 map[string]string         `json:"attributes"`
 	Authorizations             []AuthorizationAPIRequest `json:"authorizations"`
-	// CallerID is set by the handler from the X-User-ID request header.
-	// It is NOT read from the JSON body (json:"-").
-	// Used by UpdateConsent to enforce canModify on delegated consents.
+	// CallerID is set from X-User-ID header. Used to enforce canModify on delegated consents.
 	CallerID string `json:"-"`
-	// ConvertToSelfConsent, when true, strips all delegation attributes from an
-	// expired delegated consent so the principal takes direct ownership.
-	// Only allowed when: caller == principal AND delegation has expired.
-	ConvertToSelfConsent bool `json:"convertToSelfConsent,omitempty"`
 }
 
 // ConsentCreateRequest represents the internal request payload for creating a consent

--- a/consent-server/internal/consent/model/consent.go
+++ b/consent-server/internal/consent/model/consent.go
@@ -562,6 +562,10 @@ type ConsentSearchFilters struct {
 	// Required when DataPrincipalID is set so the service can verify
 	// the caller is an authorised delegate before returning results.
 	CallerID string
+	// AuthorizedConsentIDs is a list of consent IDs that the caller is explicitly
+	// authorized to see. If non-nil, the DB search will be restricted to ONLY these IDs.
+	// This ensures pagination limits and offsets are applied accurately by the database.
+	AuthorizedConsentIDs []string
 }
 
 // ConsentDetailResponse represents a detailed consent with related data

--- a/consent-server/internal/consent/model/consent.go
+++ b/consent-server/internal/consent/model/consent.go
@@ -469,6 +469,14 @@ type ConsentAPIUpdateRequest struct {
 	Purposes                   []ConsentPurposeItem      `json:"purposes"`
 	Attributes                 map[string]string         `json:"attributes"`
 	Authorizations             []AuthorizationAPIRequest `json:"authorizations"`
+	// CallerID is set by the handler from the X-User-ID request header.
+	// It is NOT read from the JSON body (json:"-").
+	// Used by UpdateConsent to enforce canModify on delegated consents.
+	CallerID string `json:"-"`
+	// ConvertToSelfConsent, when true, strips all delegation attributes from an
+	// expired delegated consent so the principal takes direct ownership.
+	// Only allowed when: caller == principal AND delegation has expired.
+	ConvertToSelfConsent bool `json:"convertToSelfConsent,omitempty"`
 }
 
 // ConsentCreateRequest represents the internal request payload for creating a consent
@@ -545,28 +553,18 @@ type ConsentSearchMetadata struct {
 
 // ConsentSearchFilters represents search criteria for consents
 type ConsentSearchFilters struct {
-	ConsentTypes    []string // e.g., ["accounts", "payments"]
-	ConsentStatuses []string // e.g., ["active", "revoked"]
-	ClientIDs       []string // TPP client IDs
-	UserIDs         []string // End-user IDs
-	PurposeNames    []string // Purpose names - returns consents containing ANY of these purposes
-	FromTime        *int64   // Unix timestamp - start of time window
-	ToTime          *int64   // Unix timestamp - end of time window
-	Limit           int
-	Offset          int
-	OrgID           string
-	// DataPrincipalID filters consents by the data subject stored in
-	// CONSENT_ATTRIBUTE (key = delegation.principal_id).
-	// Use this when a parent/guardian wants to see consents for their child.
-	// The service will verify CallerID is an authorised delegate.
-	DataPrincipalID string
-	// CallerID is the authenticated user making the list request.
-	// Required when DataPrincipalID is set so the service can verify
-	// the caller is an authorised delegate before returning results.
-	CallerID string
-	// AuthorizedConsentIDs is a list of consent IDs that the caller is explicitly
-	// authorized to see. If non-nil, the DB search will be restricted to ONLY these IDs.
-	// This ensures pagination limits and offsets are applied accurately by the database.
+	ConsentTypes         []string // e.g., ["accounts", "payments"]
+	ConsentStatuses      []string // e.g., ["active", "revoked"]
+	ClientIDs            []string // TPP client IDs
+	UserIDs              []string // End-user IDs
+	PurposeNames         []string // Purpose names - returns consents containing ANY of these purposes
+	FromTime             *int64   // Unix timestamp - start of time window
+	ToTime               *int64   // Unix timestamp - end of time window
+	Limit                int
+	Offset               int
+	OrgID                string
+	DataPrincipalID      string
+	CallerID             string
 	AuthorizedConsentIDs []string
 }
 

--- a/consent-server/internal/consent/model/consent.go
+++ b/consent-server/internal/consent/model/consent.go
@@ -287,28 +287,43 @@ type DelegationAPIRequest struct {
 
 // mergeDelegationIntoResources merges the Delegation fields into the Resources map
 // so they are persisted in the RESOURCES JSON blob of CONSENT_AUTH_RESOURCE.
-// When Delegation is nil or Resources already contains onBehalfOf, the input is
-// returned unchanged. This is the single place where delegation metadata is
-// serialized — no DB schema change required.
-func mergeDelegationIntoResources(resources interface{}, delegation *DelegationAPIRequest) interface{} {
+// When Delegation is nil the input is returned unchanged.
+//
+// Returns an error when resources is a non-object type (array, string, scalar)
+// so the caller knows the payload is incompatible and the original data is not
+// silently lost.
+func mergeDelegationIntoResources(resources interface{}, delegation *DelegationAPIRequest) (interface{}, error) {
 	if delegation == nil {
-		return resources
+		return resources, nil
 	}
 
 	// Start with an empty map or a copy of the existing resources map.
 	merged := make(map[string]interface{})
 	if resources != nil {
-		// resources may already be a map (from JSON decode) or a raw JSON []byte.
 		switch v := resources.(type) {
 		case map[string]interface{}:
 			for k, val := range v {
 				merged[k] = val
 			}
 		default:
-			// Fallback: round-trip through JSON to get a generic map.
+			// Fallback: round-trip through JSON.
+			// If the value is not a JSON object (e.g. array, string, number) we
+			// return an explicit error instead of silently dropping data.
 			b, err := json.Marshal(resources)
-			if err == nil {
-				_ = json.Unmarshal(b, &merged)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal resources for delegation merge: %w", err)
+			}
+			var decoded interface{}
+			if err := json.Unmarshal(b, &decoded); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal resources for delegation merge: %w", err)
+			}
+			m, ok := decoded.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf(
+					"resources must be a JSON object to merge delegation fields, got %T", decoded)
+			}
+			for k, val := range m {
+				merged[k] = val
 			}
 		}
 	}
@@ -325,7 +340,7 @@ func mergeDelegationIntoResources(resources interface{}, delegation *DelegationA
 	merged["canRevoke"] = delegation.CanRevoke
 	merged["canModify"] = delegation.CanModify
 
-	return merged
+	return merged, nil
 }
 
 // DelegateInfo represents a single registered delegate on a consent.
@@ -383,8 +398,10 @@ type AuthorizationAPIRequest struct {
 	Delegation *DelegationAPIRequest `json:"delegation,omitempty"`
 }
 
-// ToAuthResourceCreateRequest converts API request format to internal format
-func (req *AuthorizationAPIRequest) ToAuthResourceCreateRequest() *authmodel.ConsentAuthResourceCreateRequest {
+// ToAuthResourceCreateRequest converts API request format to internal format.
+// Returns an error when delegation fields cannot be merged into resources
+// (e.g. when resources is a non-object JSON value such as an array or string).
+func (req *AuthorizationAPIRequest) ToAuthResourceCreateRequest() (*authmodel.ConsentAuthResourceCreateRequest, error) {
 
 	AuthStatusMappings := config.Get().Consent.AuthStatusMappings
 	var userID *string
@@ -392,20 +409,28 @@ func (req *AuthorizationAPIRequest) ToAuthResourceCreateRequest() *authmodel.Con
 		userID = &req.UserID
 	}
 
-	// Default status to "created" if not provided
-	// Note: This defaults to CreatedState (unlike consent-embedded authorizations which default to ApprovedState)
-	// because direct authorization creation typically requires explicit approval workflow
+	// Default status to "created" if not provided.
+	// Note: This defaults to CreatedState (unlike consent-embedded authorizations which default to
+	// ApprovedState) because direct authorization creation typically requires an explicit approval
+	// workflow.
 	status := req.Status
 	if status == "" {
 		status = string(AuthStatusMappings.CreatedState)
 	}
 
+	// Merge delegation metadata into the resources blob so onBehalfOf/canRevoke/
+	// canModify/delegationType are persisted and readable by the delegates endpoint.
+	resources, err := mergeDelegationIntoResources(req.Resources, req.Delegation)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge delegation into resources: %w", err)
+	}
+
 	return &authmodel.ConsentAuthResourceCreateRequest{
 		AuthType:   req.Type,
 		UserID:     userID,
-		AuthStatus: status, // Store the status value in AuthStatus field
-		Resources:  req.Resources,
-	}
+		AuthStatus: status,
+		Resources:  resources,
+	}, nil
 }
 
 // AuthorizationAPIUpdateRequest represents the API payload for updating authorization resource (external format)
@@ -531,11 +556,11 @@ type ConsentSearchFilters struct {
 	// DataPrincipalID filters consents by the data subject stored in
 	// CONSENT_ATTRIBUTE (key = delegation.principal_id).
 	// Use this when a parent/guardian wants to see consents for their child.
-	// The service will verify CallerID is an authorised delegate
+	// The service will verify CallerID is an authorised delegate.
 	DataPrincipalID string
 	// CallerID is the authenticated user making the list request.
 	// Required when DataPrincipalID is set so the service can verify
-	// the caller is an authorised delegate before returning results
+	// the caller is an authorised delegate before returning results.
 	CallerID string
 }
 
@@ -557,8 +582,6 @@ type ConsentDetailResponse struct {
 	// DelegationExpired is true when guardian.valid_until has passed.
 	// The principal is now an adult or has regained capacity. The portal should
 	// prompt them to review and re-confirm or revoke inherited consents.
-	// PendingAdultReview was removed — it was identical to DelegationExpired and
-	// added no distinct information. One clear flag is better than two identical ones.
 	DelegationExpired bool `json:"delegationExpired,omitempty"`
 }
 
@@ -594,8 +617,8 @@ func (c *Consent) GetUpdatedTime() time.Time {
 	return time.Unix(0, c.UpdatedTime*int64(time.Millisecond))
 }
 
-// ToConsentCreateRequest converts API request format to internal format
-// Note: CurrentStatus will be set by the handler based on authorization states
+// ToConsentCreateRequest converts API request format to internal format.
+// Note: CurrentStatus will be set by the handler based on authorization states.
 func (req *ConsentAPIRequest) ToConsentCreateRequest() (*ConsentCreateRequest, error) {
 
 	AuthStatusMappings := config.Get().Consent.AuthStatusMappings
@@ -639,7 +662,9 @@ func (req *ConsentAPIRequest) ToConsentCreateRequest() (*ConsentCreateRequest, e
 	}
 	createReq.Purposes = purposes
 
-	// Map authorizations to auth resources
+	// Map authorizations to auth resources.
+	// mergeDelegationIntoResources ensures onBehalfOf/canRevoke/canModify/delegationType
+	// are persisted in the RESOURCES blob so the delegates endpoint can read them.
 	if len(req.Authorizations) > 0 {
 		createReq.AuthResources = make([]authmodel.ConsentAuthResourceCreateRequest, len(req.Authorizations))
 		for i, auth := range req.Authorizations {
@@ -648,17 +673,20 @@ func (req *ConsentAPIRequest) ToConsentCreateRequest() (*ConsentCreateRequest, e
 				userID = &auth.UserID
 			}
 
-			// Default status to "approved" if not provided
-			// Note: Consent-embedded authorizations default to ApprovedState (unlike direct auth resource
-			// creation which defaults to CreatedState) because they're created as part of consent flow
+			// Default status to "approved" if not provided.
+			// Note: Consent-embedded authorizations default to ApprovedState (unlike direct auth
+			// resource creation which defaults to CreatedState) because they're created as part of
+			// the consent flow.
 			status := auth.Status
 			if status == "" {
 				status = string(AuthStatusMappings.ApprovedState)
 			}
 
-			// persisting, so onBehalfOf/canRevoke/canModify/delegationType are
-			// stored in the RESOURCES blob and readable by the delegates endpoint.
-			resources := mergeDelegationIntoResources(auth.Resources, auth.Delegation)
+			resources, err := mergeDelegationIntoResources(auth.Resources, auth.Delegation)
+			if err != nil {
+				return nil, fmt.Errorf("failed to merge delegation for authorization %d: %w", i, err)
+			}
+
 			createReq.AuthResources[i] = authmodel.ConsentAuthResourceCreateRequest{
 				AuthType:   auth.Type,
 				UserID:     userID,
@@ -671,8 +699,8 @@ func (req *ConsentAPIRequest) ToConsentCreateRequest() (*ConsentCreateRequest, e
 	return createReq, nil
 }
 
-// ToConsentUpdateRequest converts API update request format to internal format
-// Note: CurrentStatus will be set by the handler based on authorization states
+// ToConsentUpdateRequest converts API update request format to internal format.
+// Note: CurrentStatus will be set by the handler based on authorization states.
 func (req *ConsentAPIUpdateRequest) ToConsentUpdateRequest() (*ConsentUpdateRequest, error) {
 
 	AuthStatusMappings := config.Get().Consent.AuthStatusMappings
@@ -723,8 +751,10 @@ func (req *ConsentAPIUpdateRequest) ToConsentUpdateRequest() (*ConsentUpdateRequ
 		DataAccessValidityDuration: req.DataAccessValidityDuration,
 	}
 
-	// Map authorizations to auth resources
-	// If Authorizations is not nil (even if empty), set AuthResources to indicate intent to update
+	// Map authorizations to auth resources.
+	// If Authorizations is not nil (even if empty), set AuthResources to indicate intent to update.
+	// mergeDelegationIntoResources ensures delegation fields are persisted in the RESOURCES blob
+	// on update too — same as create.
 	if req.Authorizations != nil {
 		updateReq.AuthResources = make([]authmodel.ConsentAuthResourceCreateRequest, len(req.Authorizations))
 		for i, auth := range req.Authorizations {
@@ -733,20 +763,22 @@ func (req *ConsentAPIUpdateRequest) ToConsentUpdateRequest() (*ConsentUpdateRequ
 				userID = &auth.UserID
 			}
 
-			// Default status to "approved" if not provided
-			// Note: Consent-embedded authorizations default to ApprovedState (unlike direct auth resource
-			// creation which defaults to CreatedState) because they're created as part of consent flow
+			// Default status to "approved" if not provided.
+			// Note: Consent-embedded authorizations default to ApprovedState.
 			status := auth.Status
 			if status == "" {
 				status = string(AuthStatusMappings.ApprovedState)
 			}
 
-			// fields must be written into the RESOURCES blob on update too.
-			resources := mergeDelegationIntoResources(auth.Resources, auth.Delegation)
+			resources, err := mergeDelegationIntoResources(auth.Resources, auth.Delegation)
+			if err != nil {
+				return nil, fmt.Errorf("failed to merge delegation for authorization %d: %w", i, err)
+			}
+
 			updateReq.AuthResources[i] = authmodel.ConsentAuthResourceCreateRequest{
 				AuthType:   auth.Type,
 				UserID:     userID,
-				AuthStatus: status, // Store the status value
+				AuthStatus: status,
 				Resources:  resources,
 			}
 		}

--- a/consent-server/internal/consent/model/consent.go
+++ b/consent-server/internal/consent/model/consent.go
@@ -579,10 +579,12 @@ type ConsentDetailResponse struct {
 	DataAccessValidityDuration int64                 `json:"dataAccessValidityDuration"`
 	Attributes                 map[string]string     `json:"attributes"`
 	Authorizations             []AuthorizationDetail `json:"authorizations"`
-	// DelegationExpired is true when guardian.valid_until has passed.
+	// IsDelegationExpired is true when guardian.valid_until has passed.
 	// The principal is now an adult or has regained capacity. The portal should
 	// prompt them to review and re-confirm or revoke inherited consents.
-	DelegationExpired bool `json:"delegationExpired,omitempty"`
+	// Uses the same wire name as DelegateListResponse so clients see one
+	// canonical field name for this concept across all consent endpoints.
+	IsDelegationExpired bool `json:"isDelegationExpired,omitempty"`
 }
 
 // AuthorizationDetail represents authorization resource details

--- a/consent-server/internal/consent/model/consent.go
+++ b/consent-server/internal/consent/model/consent.go
@@ -28,6 +28,64 @@ import (
 	"github.com/wso2/openfgc/internal/system/config"
 )
 
+// ─── Delegation support ───────────────────────────────────────────────────────
+// All delegation data is stored in the existing CONSENT_ATTRIBUTE table as
+
+// Attribute key constants for delegation metadata stored in CONSENT_ATTRIBUTE.
+const (
+	// AttrDelegationType is the kind of delegation.
+	// Examples: "parental_biological", "parental_legal", "guardian", "carer", "power_of_attorney"
+	AttrDelegationType = "delegation.type"
+
+	// AttrDelegationPrincipalID is the userId of the actual data subject
+	// (the person WHOSE data is being processed, not the person giving consent).
+	AttrDelegationPrincipalID = "delegation.principal_id"
+
+	// AttrGuardianValidUntil is the Unix timestamp (seconds) after which the
+	// delegation expires. For minors, set this to the child's 18th birthday.
+	// After this point only the principal may act on the consent.
+	AttrGuardianValidUntil = "guardian.valid_until"
+
+	// AttrGuardianRevocationPolicy controls who may revoke a delegated consent.
+	// Use RevocationPolicyAny or RevocationPolicySubjectOnly below.
+	AttrGuardianRevocationPolicy = "guardian.revocation_policy"
+)
+
+// RevocationPolicy controls who may revoke a delegated consent.
+type RevocationPolicy string
+
+const (
+	// RevocationPolicyAny allows any registered delegate with canRevoke=true to revoke.
+	RevocationPolicyAny RevocationPolicy = "ANY"
+	// RevocationPolicySubjectOnly allows only the data principal to revoke.
+	RevocationPolicySubjectOnly RevocationPolicy = "SUBJECT_ONLY"
+)
+
+// DelegationConfig is a parsed view of the delegation CONSENT_ATTRIBUTE rows.
+// Built at runtime from the attribute map — not stored as a separate struct.
+type DelegationConfig struct {
+	Type             string
+	PrincipalID      string
+	ValidUntil       int64
+	RevocationPolicy RevocationPolicy
+}
+
+// IsGuardianConsent returns true when this consent was given on behalf of someone else.
+func (d DelegationConfig) IsGuardianConsent() bool {
+	return d.Type != ""
+}
+
+// IsExpired returns true when the delegation period has ended.
+// When true, only the data principal may act on the consent.
+func (d DelegationConfig) IsExpired() bool {
+	if d.ValidUntil == 0 {
+		return false
+	}
+	return time.Now().Unix() > d.ValidUntil
+}
+
+// ─── end delegation support ───────────────────────────────────────────────────
+
 // Consent represents the CONSENT table
 type Consent struct {
 	ConsentID                  string `db:"CONSENT_ID" json:"consentId"`
@@ -195,7 +253,79 @@ type ConsentAPIRequest struct {
 	Purposes                   []ConsentPurposeItem      `json:"purposes" binding:"required,min=1"`
 	Attributes                 map[string]string         `json:"attributes,omitempty"`
 	Authorizations             []AuthorizationAPIRequest `json:"authorizations"` // Remove omitempty to allow explicit empty array in updates
+	// CallerID is set by the handler from the X-User-ID request header.
+	// It is NOT read from the JSON body (json:"-").
+	// Used by delegation validation to ensure the consent initiator is not
+	// also the data principal — cannot self-delegate
+	CallerID string `json:"-"`
+	// PrincipalID is the userId of the data subject when this consent is being
+	// given on behalf of another person (e.g., parent creating consent for child).
+	// It mirrors the delegation.principal_id attribute stored in CONSENT_ATTRIBUTE.
+	// Provided as a convenience field on the request for validation.
+	PrincipalID string `json:"principalId,omitempty"`
 }
+
+// ─── Delegation response types ────────────────────────────────────────────────
+// These types support the GET /consents/{consentId}/delegates endpoint and
+// the delegate-related test assertions.
+
+// DelegationAPIRequest carries optional delegation metadata on an authorization
+// resource at consent creation time. It is used when the consent is being given
+// on behalf of another person (e.g., parent for child). Stored in the RESOURCES
+// JSON blob of CONSENT_AUTH_RESOURCE — no schema change needed.
+type DelegationAPIRequest struct {
+	// Type is the delegation relationship, e.g. "parental_biological", "carer".
+	Type string `json:"type,omitempty"`
+	// PrincipalID is the userId of the actual data subject (the person whose data
+	// is being processed). Must match delegation.principal_id in CONSENT_ATTRIBUTE.
+	PrincipalID string `json:"principalId,omitempty"`
+	// CanRevoke indicates whether this delegate may revoke the consent.
+	CanRevoke bool `json:"canRevoke,omitempty"`
+	// CanModify indicates whether this delegate may modify the consent.
+	CanModify bool `json:"canModify,omitempty"`
+}
+
+// DelegateInfo represents a single registered delegate on a consent.
+// Assembled at read time from a CONSENT_AUTH_RESOURCE row and its RESOURCES blob.
+type DelegateInfo struct {
+	// AuthID is the CONSENT_AUTH_RESOURCE.AUTH_ID for this delegate row.
+	AuthID string `json:"authId"`
+	// UserID is the delegate's userId (e.g., the parent's account ID).
+	UserID string `json:"userId"`
+	// DelegationType mirrors the delegation.type value (e.g., "parental_biological").
+	DelegationType string `json:"delegationType,omitempty"`
+	// Status is the CONSENT_AUTH_RESOURCE.AUTH_STATUS (e.g., "approved").
+	Status string `json:"status"`
+	// CanRevoke is true when this delegate may revoke the consent.
+	CanRevoke bool `json:"canRevoke"`
+	// CanModify is true when this delegate may modify the consent.
+	CanModify bool `json:"canModify"`
+	// OnBehalfOf is the principalID this delegate is acting for.
+	OnBehalfOf string `json:"onBehalfOf,omitempty"`
+	// UpdatedTime is the CONSENT_AUTH_RESOURCE.UPDATED_TIME in milliseconds.
+	UpdatedTime int64 `json:"updatedTime"`
+}
+
+// DelegateListResponse is the response body for GET /consents/{consentId}/delegates.
+// It aggregates all delegate auth resources for a single consent.
+type DelegateListResponse struct {
+	// ConsentID is the consent this response belongs to.
+	ConsentID string `json:"consentId"`
+	// DataPrincipalID is the userId of the data subject (from delegation.principal_id).
+	DataPrincipalID string `json:"dataPrincipalId,omitempty"`
+	// RevocationPolicy mirrors guardian.revocation_policy (e.g., "ANY").
+	RevocationPolicy string `json:"revocationPolicy,omitempty"`
+	// ValidUntil is the delegation expiry Unix timestamp (from guardian.valid_until).
+	ValidUntil int64 `json:"validUntil,omitempty"`
+	// IsDelegationExpired is true when the current time is past ValidUntil.
+	IsDelegationExpired bool `json:"isDelegationExpired"`
+	// DelegateCount is the total number of delegates registered on this consent.
+	DelegateCount int `json:"delegateCount"`
+	// Delegates is the list of individual delegate records.
+	Delegates []DelegateInfo `json:"delegates"`
+}
+
+// ─── end delegation response types ───────────────────────────────────────────
 
 // AuthorizationAPIRequest represents the API payload for authorization resource (external format)
 // Status field represents the authorization status/state (created, approved, rejected, or custom)
@@ -204,6 +334,10 @@ type AuthorizationAPIRequest struct {
 	Type      string      `json:"type" binding:"required"`
 	Status    string      `json:"status,omitempty"` // Optional: defaults to "approved" if not provided
 	Resources interface{} `json:"resources,omitempty"`
+	// Delegation carries optional delegation metadata when this authorization represents
+	// a delegate acting on behalf of a data principal. Stored inside the RESOURCES JSON blob.
+	// Not a separate DB column — no schema change required.
+	Delegation *DelegationAPIRequest `json:"delegation,omitempty"`
 }
 
 // ToAuthResourceCreateRequest converts API request format to internal format
@@ -351,6 +485,15 @@ type ConsentSearchFilters struct {
 	Limit           int
 	Offset          int
 	OrgID           string
+	// DataPrincipalID filters consents by the data subject stored in
+	// CONSENT_ATTRIBUTE (key = delegation.principal_id).
+	// Use this when a parent/guardian wants to see consents for their child.
+	// The service will verify CallerID is an authorised delegate
+	DataPrincipalID string
+	// CallerID is the authenticated user making the list request.
+	// Required when DataPrincipalID is set so the service can verify
+	// the caller is an authorised delegate before returning results
+	CallerID string
 }
 
 // ConsentDetailResponse represents a detailed consent with related data
@@ -368,6 +511,12 @@ type ConsentDetailResponse struct {
 	DataAccessValidityDuration int64                 `json:"dataAccessValidityDuration"`
 	Attributes                 map[string]string     `json:"attributes"`
 	Authorizations             []AuthorizationDetail `json:"authorizations"`
+	// DelegationExpired is true when guardian.valid_until has passed.
+	// The principal is now an adult or has regained capacity. The portal should
+	// prompt them to review and re-confirm or revoke inherited consents.
+	// PendingAdultReview was removed — it was identical to DelegationExpired and
+	// added no distinct information. One clear flag is better than two identical ones.
+	DelegationExpired bool `json:"delegationExpired,omitempty"`
 }
 
 // AuthorizationDetail represents authorization resource details

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -525,11 +525,6 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 	//
 	// Failing open (skipping this check when CallerID is empty) would allow any
 	// caller to read another person's consents simply by omitting X-User-ID.
-	//
-	// authorizedConsentIDSet:
-	//   nil  → caller is the principal; no per-consent filter needed.
-	//   non-nil → caller is a delegate; restrict results to these consent IDs.
-	var authorizedConsentIDSet map[string]bool
 	if filters.DataPrincipalID != "" {
 		// Require an explicit caller identity — no anonymous access to another
 		// principal's consents.
@@ -552,9 +547,7 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 			return nil, serviceerror.CustomServiceError(ErrorInternalServerError, authErr.Error())
 		}
 
-		// authorizedIDs == nil  → callerID == principalID (self-access, unrestricted).
 		// authorizedIDs == []   → no valid delegate binding found; deny.
-		// authorizedIDs non-empty → restrict to those specific consent IDs.
 		if authorizedIDs != nil && len(authorizedIDs) == 0 {
 			logger.Warn("Caller not authorized for principal",
 				log.String("caller_id", filters.CallerID),
@@ -565,14 +558,11 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 					filters.CallerID, filters.DataPrincipalID),
 			)
 		}
+
+		// Pass the authorized IDs directly to the DB filters so pagination works natively
 		if authorizedIDs != nil {
-			// Build a set for O(1) lookup during post-filter.
-			authorizedConsentIDSet = make(map[string]bool, len(authorizedIDs))
-			for _, id := range authorizedIDs {
-				authorizedConsentIDSet[id] = true
-			}
+			filters.AuthorizedConsentIDs = authorizedIDs
 		}
-		// authorizedIDs == nil: principal self-access; authorizedConsentIDSet stays nil.
 	}
 	// ── end delegate authorization check ─────────────────────────────────────
 
@@ -584,26 +574,11 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 		return nil, serviceerror.CustomServiceError(ErrorInternalServerError, err.Error())
 	}
 
-	// Post-filter to authorized consents to prevent unauthorized visibility.
-	// We correct `total` using authorizedConsentIDSet size because the DB count
-	// runs before this filter. Note: total may be higher than actual if extra
-	// filters (status/type) are applied.
-	if authorizedConsentIDSet != nil {
-		filtered := make([]model.Consent, 0, len(consents))
-		for _, c := range consents {
-			if authorizedConsentIDSet[c.ConsentID] {
-				filtered = append(filtered, c)
-			}
-		}
-		total = len(authorizedConsentIDSet)
-		consents = filtered
-	}
-
 	if len(consents) == 0 {
 		return &model.ConsentDetailSearchResponse{
 			Data: []model.ConsentDetailResponse{},
 			Metadata: model.ConsentSearchMetadata{
-				Total:  0,
+				Total:  0, // Will be 0 because result set is empty
 				Limit:  filters.Limit,
 				Offset: filters.Offset,
 				Count:  0,

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -991,7 +991,8 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 			return nil, serviceerror.CustomServiceError(ErrorValidationFailed,
 				"delegation must be expired before the principal can convert to self-consent")
 		}
-		if req.CallerID != convDelegCfg.PrincipalID {
+		callerID := strings.TrimSpace(req.CallerID)
+		if callerID != convDelegCfg.PrincipalID {
 			return nil, serviceerror.CustomServiceError(ErrorRevocationNotPermitted,
 				fmt.Sprintf("only the principal '%s' can convert this consent to self-consent",
 					convDelegCfg.PrincipalID))
@@ -1015,14 +1016,14 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 		convAuditID := utils.GenerateUUID()
 		convReason := fmt.Sprintf(
 			"[conversionToSelfConsent=true; actor=%s; fromDelegationType=%s; delegationExpired=true]",
-			req.CallerID, convDelegCfg.Type)
+			callerID, convDelegCfg.Type)
 		convAudit := &model.ConsentStatusAudit{
 			StatusAuditID:  convAuditID,
 			ConsentID:      consentID,
 			CurrentStatus:  existing.CurrentStatus,
 			ActionTime:     utils.GetCurrentTimeMillis(),
 			Reason:         &convReason,
-			ActionBy:       &req.CallerID,
+			ActionBy:       &callerID,
 			PreviousStatus: &existing.CurrentStatus,
 			OrgID:          orgID,
 		}
@@ -1310,7 +1311,7 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 
 		if delegCfg.IsGuardianConsent() {
 			principalID := delegCfg.PrincipalID
-			callerID := req.ActionBy
+			callerID := strings.TrimSpace(req.ActionBy)
 			isPrincipal := callerID == principalID
 
 			if delegCfg.IsExpired() {
@@ -2267,8 +2268,6 @@ func (s *consentService) validatePurposes(
 	}
 
 	// Validate no duplicate elements across ALL resolved purposes
-	// This check happens AFTER resolution because we now have the complete picture
-	// of all elements across all purposes (including auto-filled ones)
 	if err := s.validateNoDuplicateElementsAcrossPurposes(resolvedPurposes); err != nil {
 		logger.Warn("Duplicate element validation failed", log.Error(err))
 		return nil, err

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -46,8 +46,8 @@ type ConsentService interface {
 	ValidateConsent(ctx context.Context, req model.ValidateRequest, orgID string) (*model.ValidateResponse, *serviceerror.ServiceError)
 	SearchConsentsByAttribute(ctx context.Context, key, value, orgID string) (*model.ConsentAttributeSearchResponse, *serviceerror.ServiceError)
 	// GetConsentDelegates returns all registered delegates for a single consent.
-	// Reads from CONSENT_AUTH_RESOURCE rows (RESOURCES JSON blob) and CONSENT_ATTRIBUTE rows.
-	GetConsentDelegates(ctx context.Context, consentID, orgID string) (*model.DelegateListResponse, *serviceerror.ServiceError)
+	// The caller must be the data principal or an active delegate to access this data.
+	GetConsentDelegates(ctx context.Context, consentID, orgID, callerID string) (*model.DelegateListResponse, *serviceerror.ServiceError)
 }
 
 // consentService implements the ConsentService interface
@@ -1870,7 +1870,7 @@ func buildConsentResponse(
 // It reads CONSENT_AUTH_RESOURCE rows (RESOURCES JSON blob for per-delegate flags)
 // and CONSENT_ATTRIBUTE rows (for delegation.principal_id, guardian.valid_until, etc.).
 
-func (consentService *consentService) GetConsentDelegates(ctx context.Context, consentID, orgID string) (*model.DelegateListResponse, *serviceerror.ServiceError) {
+func (consentService *consentService) GetConsentDelegates(ctx context.Context, consentID, orgID, callerID string) (*model.DelegateListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().WithContext(ctx)
 	logger.Info("Getting consent delegates",
 		log.String("consent_id", consentID),
@@ -1897,6 +1897,50 @@ func (consentService *consentService) GetConsentDelegates(ctx context.Context, c
 		attMap[a.AttKey] = a.AttValue
 	}
 	delegCfg := parseDelegationConfig(attMap)
+
+	// ── Caller authorization check ───────────────────────────────────────
+	// The caller must be the data principal or an active, non-expired delegate.
+	// This prevents any authenticated user from enumerating delegate relationships
+	// by guessing consent IDs.
+	if delegCfg.IsGuardianConsent() {
+		callerID = strings.TrimSpace(callerID)
+		principalID := delegCfg.PrincipalID
+		if callerID != principalID {
+			// Caller is not the principal — check if they are an active delegate.
+			authResources, arErr := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)
+			if arErr != nil {
+				return nil, serviceerror.CustomServiceError(ErrorInternalServerError, arErr.Error())
+			}
+			approvedStatus := string(config.Get().Consent.AuthStatusMappings.ApprovedState)
+			isAuthorized := false
+			for _, ar := range authResources {
+				if ar.UserID == nil || *ar.UserID != callerID {
+					continue
+				}
+				if ar.AuthStatus != approvedStatus {
+					continue
+				}
+				if ar.Resources == nil || *ar.Resources == "" {
+					continue
+				}
+				var res map[string]interface{}
+				if json.Unmarshal([]byte(*ar.Resources), &res) != nil {
+					continue
+				}
+				if onBehalfOf, _ := res["onBehalfOf"].(string); onBehalfOf == principalID {
+					isAuthorized = true
+					break
+				}
+			}
+			if !isAuthorized {
+				logger.Warn("GetConsentDelegates denied: caller is not principal or delegate",
+					log.String("caller_id", callerID),
+					log.String("principal_id", principalID))
+				return nil, serviceerror.CustomServiceError(ErrorNotAuthorizedForPrincipal,
+					fmt.Sprintf("caller '%s' is not authorized to view delegates for this consent", callerID))
+			}
+		}
+	}
 
 	// Load all auth resource rows for this consent.
 	authResources, err := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)
@@ -2268,6 +2312,8 @@ func (s *consentService) validatePurposes(
 	}
 
 	// Validate no duplicate elements across ALL resolved purposes
+	// This check happens AFTER resolution because we now have the complete picture
+	// of all elements across all purposes (including auto-filled ones)
 	if err := s.validateNoDuplicateElementsAcrossPurposes(resolvedPurposes); err != nil {
 		logger.Warn("Duplicate element validation failed", log.Error(err))
 		return nil, err

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -527,15 +527,8 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 		filters.Offset = 0
 	}
 
-	// ── Delegate authorization check ─────────────────────────────────────────
-	// When dataPrincipalId is set, the caller must prove they are either the
-	// principal themselves or an active delegate for that principal.
-	//
-	// Failing open (skipping this check when CallerID is empty) would allow any
-	// caller to read another person's consents simply by omitting X-User-ID.
+	// Delegate authorization: when dataPrincipalId is set, verify caller is the principal or a delegate.
 	if filters.DataPrincipalID != "" {
-		// Require an explicit caller identity — no anonymous access to another
-		// principal's consents.
 		if filters.CallerID == "" {
 			logger.Warn("dataPrincipalId set but caller identity is missing")
 			return nil, serviceerror.CustomServiceError(
@@ -556,8 +549,7 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 		}
 
 		if authorizedIDs == nil {
-			// callerID == principalID — unrestricted self-access.
-			// Clear DataPrincipalID so the store does not filter by delegation attribute.
+			// Self-access — clear filter so store does not join on delegation attribute.
 			filters.DataPrincipalID = ""
 		} else if len(authorizedIDs) == 0 {
 			logger.Warn("Caller not authorized for principal",
@@ -569,11 +561,9 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 					filters.CallerID, filters.DataPrincipalID),
 			)
 		} else {
-			// Pass the authorized IDs directly to the DB filters so pagination works natively
 			filters.AuthorizedConsentIDs = authorizedIDs
 		}
 	}
-	// ── end delegate authorization check ─────────────────────────────────────
 
 	// Step 1: Search consents
 	consentStore := consentService.stores.Consent
@@ -760,15 +750,8 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 			fmt.Sprintf("Client '%s' is not authorized to update consent '%s'", clientID, consentID))
 	}
 
-	// ── Delegation-aware modify check ────────────────────────────────────────
-	// For self-consented records this is a no-op (IsGuardianConsent==false).
-	// For delegated consents the rules are:
-	//   if delegation expired    → only the principal (now adult) may modify
-	//   if caller == principal   → allowed, EXCEPT under active ANY-policy
+	// Delegation-aware modify check.
 	//                              delegation where the guardian controls modifications
-	//   if caller == delegate    → the delegate row must have canModify=true AND
-	//                              onBehalfOf == principalID
-	// Note: Unlike revocation, SUBJECT_ONLY policy does NOT block delegates
 	// from modifying — it only restricts who can revoke.
 	{
 		attributes, attErr := consentStore.GetAttributesByConsentID(ctx, consentID, orgID)
@@ -856,7 +839,6 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 			}
 		}
 	}
-	// ── end delegation modify check ─────────────────────────────────────────
 
 	currentTime := utils.GetCurrentTimeMillis()
 	previousStatus := existing.CurrentStatus
@@ -966,79 +948,6 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 			})
 		}
 	}
-
-	// ── Convert-to-self-consent ─────────────────────────────────────────
-	// When a delegated consent's guardian period has expired, the principal
-	// can convert it to a self-consent by stripping all delegation metadata.
-	// This lets the now-adult child (or recovered patient, etc.) take
-	// ownership of the existing consent record without creating a duplicate.
-	if req.ConvertToSelfConsent {
-		convAttrs, convErr := consentStore.GetAttributesByConsentID(ctx, consentID, orgID)
-		if convErr != nil {
-			logger.Error("Failed to load attributes for conversion check",
-				log.Error(convErr), log.String("consent_id", consentID))
-			return nil, serviceerror.CustomServiceError(ErrorInternalServerError, convErr.Error())
-		}
-		convMap := make(map[string]string)
-		for _, a := range convAttrs {
-			convMap[a.AttKey] = a.AttValue
-		}
-		convDelegCfg := parseDelegationConfig(convMap)
-
-		if !convDelegCfg.IsGuardianConsent() {
-			return nil, serviceerror.CustomServiceError(ErrorValidationFailed,
-				"convertToSelfConsent is only valid on delegated consents")
-		}
-		if !convDelegCfg.IsExpired() {
-			return nil, serviceerror.CustomServiceError(ErrorValidationFailed,
-				"delegation must be expired before the principal can convert to self-consent")
-		}
-		callerID := strings.TrimSpace(req.CallerID)
-		if callerID != convDelegCfg.PrincipalID {
-			return nil, serviceerror.CustomServiceError(ErrorRevocationNotPermitted,
-				fmt.Sprintf("only the principal '%s' can convert this consent to self-consent",
-					convDelegCfg.PrincipalID))
-		}
-
-		// Strip all 4 delegation attributes in the transaction
-		delegationKeys := []string{
-			model.AttrDelegationType,
-			model.AttrDelegationPrincipalID,
-			model.AttrGuardianValidUntil,
-			model.AttrGuardianRevocationPolicy,
-		}
-		for _, key := range delegationKeys {
-			k := key // capture for closure
-			queries = append(queries, func(tx dbmodel.TxInterface) error {
-				return consentStore.DeleteAttributeByKey(tx, consentID, k, orgID)
-			})
-		}
-
-		// Audit the conversion
-		convAuditID := utils.GenerateUUID()
-		convReason := fmt.Sprintf(
-			"[conversionToSelfConsent=true; actor=%s; fromDelegationType=%s; delegationExpired=true]",
-			callerID, convDelegCfg.Type)
-		convAudit := &model.ConsentStatusAudit{
-			StatusAuditID:  convAuditID,
-			ConsentID:      consentID,
-			CurrentStatus:  existing.CurrentStatus,
-			ActionTime:     utils.GetCurrentTimeMillis(),
-			Reason:         &convReason,
-			ActionBy:       &callerID,
-			PreviousStatus: &existing.CurrentStatus,
-			OrgID:          orgID,
-		}
-		queries = append(queries, func(tx dbmodel.TxInterface) error {
-			return consentStore.CreateStatusAudit(tx, convAudit)
-		})
-
-		logger.Info("Converting delegated consent to self-consent",
-			log.String("consent_id", consentID),
-			log.String("principal_id", convDelegCfg.PrincipalID),
-			log.String("former_delegation_type", convDelegCfg.Type))
-	}
-	// ── end convert-to-self-consent ─────────────────────────────────────
 
 	// Update authorization resources if provided
 	if updateReq.AuthResources != nil {
@@ -1292,8 +1201,6 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 	// For normal self-consented records this entire block is a no-op because
 	// parseDelegationConfig returns IsGuardianConsent()=false.
 	//
-	// For delegated consents the rules are:
-	//   if delegation expired       → only the principal (now adult) may revoke
 	//   if policy = SUBJECT_ONLY    → only the principal may revoke; delegates blocked
 	//   if policy = ANY             → only delegates with canRevoke=true may revoke; principal blocked
 	//   if policy = BOTH            → both principal and delegates with canRevoke=true may revoke
@@ -1420,7 +1327,6 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 			}
 		}
 	}
-	// ── end delegation revocation check ──────────────────────────────────────────
 
 	currentTime := utils.GetCurrentTimeMillis()
 
@@ -1428,7 +1334,7 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 	auditID := utils.GenerateUUID()
 	reason := req.RevocationReason
 
-	// ── Delegation-aware audit enrichment ───────────────────────────────────
+	// Delegation-aware audit enrichment.
 	// When the revoker is acting as a delegate for another person, prepend a
 	// structured marker to the Reason field so the audit log answers
 	// "who revoked on whose behalf?" without a schema change. The marker is
@@ -1467,7 +1373,6 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 			}
 		}
 	}
-	// ── end delegation audit enrichment ─────────────────────────────────────
 
 	audit := &model.ConsentStatusAudit{
 		StatusAuditID:  auditID,
@@ -1913,7 +1818,7 @@ func (consentService *consentService) GetConsentDelegates(ctx context.Context, c
 		}, nil
 	}
 
-	// ── Caller authorization check ───────────────────────────────────────
+	// Caller authorization check.
 	// The caller must be the data principal or an active, non-expired delegate.
 	// This prevents any authenticated user from enumerating delegate relationships
 	// by guessing consent IDs.

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -578,9 +578,10 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 		return nil, serviceerror.CustomServiceError(ErrorInternalServerError, err.Error())
 	}
 
-	// Post-filter to the specific consents the delegate is authorized for.
-	// This prevents a delegate binding on one consent from granting visibility
-	// into all consents of the same principal.
+	// Post-filter to authorized consents to prevent unauthorized visibility.
+	// We correct `total` using authorizedConsentIDSet size because the DB count
+	// runs before this filter. Note: total may be higher than actual if extra
+	// filters (status/type) are applied.
 	if authorizedConsentIDSet != nil {
 		filtered := make([]model.Consent, 0, len(consents))
 		for _, c := range consents {
@@ -588,7 +589,7 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 				filtered = append(filtered, c)
 			}
 		}
-		total = len(filtered)
+		total = len(authorizedConsentIDSet)
 		consents = filtered
 	}
 
@@ -634,7 +635,6 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 	// Step 5: Assemble detailed responses
 	detailedResponses := make([]model.ConsentDetailResponse, 0, len(consents))
 	for _, consent := range consents {
-		// Build authorizations - initialize as empty slice
 		authorizations := make([]model.AuthorizationDetail, 0)
 		for _, auth := range authsByConsent[consent.ConsentID] {
 			var resources interface{}
@@ -657,23 +657,19 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 			})
 		}
 
-		// Resolve purposes for this consent
 		purposes, err := consentService.getResolvedConsentPurposes(ctx, consent.ConsentID, filters.OrgID)
 		if err != nil {
 			logger.Warn("Failed to resolve purposes for consent",
 				log.String("consent_id", consent.ConsentID),
 				log.Error(err))
-			// Continue with empty purposes rather than failing
 			purposes = []model.ConsentPurposeItem{}
 		}
 
-		// Get attributes (already grouped by consent ID)
 		attributes := attributesByConsent[consent.ConsentID]
 		if attributes == nil {
 			attributes = make(map[string]string)
 		}
 
-		// Dereference pointer fields for response
 		frequency := 0
 		if consent.ConsentFrequency != nil {
 			frequency = *consent.ConsentFrequency
@@ -705,10 +701,8 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 			DataAccessValidityDuration: dataAccessValidityDuration,
 			Attributes:                 attributes,
 			Authorizations:             authorizations,
-			// DelegationExpired is true when the guardian period has passed.
-			// The data principal (now adult/capable) holds full authority.
-			// The portal uses this flag to prompt the principal to review inherited consents.
-			DelegationExpired: parseDelegationConfig(attributes).IsGuardianConsent() && parseDelegationConfig(attributes).IsExpired(),
+			// True when guardian period ends; prompts principal to review inherited consents.
+			IsDelegationExpired: parseDelegationConfig(attributes).IsGuardianConsent() && parseDelegationConfig(attributes).IsExpired(),
 		})
 	}
 

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -81,42 +81,48 @@ func parseDelegationConfig(attMap map[string]string) model.DelegationConfig {
 	}
 }
 
-// isCallerAuthorizedForPrincipal returns true when callerID is allowed to read or
-// act on consents where principalID is the data subject
+// isCallerAuthorizedForPrincipal returns the list of consent IDs the caller is
+// authorized to access for the given principal.
 //
-// Access is granted when:
-//   - callerID == principalID  (people can always access their own data), OR
-//   - callerID has an APPROVED auth resource row on any consent whose
-//     delegation.principal_id == principalID, with onBehalfOf == principalID
-//     in the RESOURCES JSON blob, AND the delegation has not yet expired.
+//   - A nil return means callerID == principalID (the principal sees all their own
+//     consents — unrestricted). The caller MUST treat nil as "no filter needed".
+//   - An empty slice means the caller has no delegate binding and is not authorized.
+//   - A non-empty slice lists the specific consent IDs the delegate may access.
 //
-// Uses FindConsentIDsByAttribute (queries CONSENT_ATTRIBUTE)
+// Authorization for a delegate is granted per-consent when:
+//   - The consent's delegation.principal_id attribute equals principalID.
+//   - The delegation has not yet expired (guardian.valid_until is in the future or unset).
+//   - The caller has an APPROVED auth resource row on that consent with
+//     onBehalfOf == principalID in the RESOURCES JSON blob.
+//
+// This per-consent check prevents a delegate binding on one consent from granting
+// visibility into all consents of the same principal.
 func (consentService *consentService) isCallerAuthorizedForPrincipal(
 	ctx context.Context,
 	callerID, principalID, orgID string,
-) (bool, error) {
-	// Principals can always access their own data.
+) ([]string, error) {
+	// Principals can always access all of their own consents — no per-consent check needed.
 	if callerID == principalID {
-		return true, nil
+		return nil, nil // nil signals "unrestricted / self-access"
 	}
 
-	// Find all consents where this person is the data subject.
-	// FindConsentIDsByAttribute queries CONSENT_ATTRIBUTE directly.
+	// Find every consent that lists principalID as the delegation subject.
 	consentStore := consentService.stores.Consent
 	consentIDs, err := consentStore.FindConsentIDsByAttribute(
 		ctx, model.AttrDelegationPrincipalID, principalID, orgID,
 	)
 	if err != nil {
-		return false, fmt.Errorf("failed to look up delegated consents: %w", err)
+		return nil, fmt.Errorf("failed to look up delegated consents: %w", err)
 	}
 	if len(consentIDs) == 0 {
-		return false, nil
+		return []string{}, nil
 	}
 
 	approvedStatus := string(config.Get().Consent.AuthStatusMappings.ApprovedState)
+	authorizedIDs := make([]string, 0)
 
 	for _, consentID := range consentIDs {
-		// Load attributes to check whether delegation has expired
+		// Load attributes to check whether the delegation period is still active.
 		attributes, err := consentStore.GetAttributesByConsentID(ctx, consentID, orgID)
 		if err != nil {
 			continue
@@ -127,11 +133,14 @@ func (consentService *consentService) isCallerAuthorizedForPrincipal(
 		}
 		cfg := parseDelegationConfig(attMap)
 		if cfg.IsExpired() {
-			// Delegation period ended — this delegate's rights have lapsed.
+			// Delegation period ended — this delegate's access rights have lapsed.
 			continue
 		}
 
-		// Check whether callerID has an active auth resource with onBehalfOf = principalID.
+		// Check whether callerID has an approved auth resource row for this consent
+		// where onBehalfOf matches principalID.  Checking onBehalfOf prevents an
+		// unrelated canRevoke=true row from accidentally granting access to a
+		// different principal's data.
 		authResources, err := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)
 		if err != nil {
 			continue
@@ -151,11 +160,13 @@ func (consentService *consentService) isCallerAuthorizedForPrincipal(
 				continue
 			}
 			if onBehalfOf, _ := res["onBehalfOf"].(string); onBehalfOf == principalID {
-				return true, nil
+				// Caller is an authorized delegate for this specific consent.
+				authorizedIDs = append(authorizedIDs, consentID)
+				break // No need to check other auth rows for the same consent.
 			}
 		}
 	}
-	return false, nil
+	return authorizedIDs, nil
 }
 
 // ── end delegation helpers ────────────────────────────────────────────────────
@@ -502,11 +513,29 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 		filters.Offset = 0
 	}
 
-	// When a caller requests another person's consents via dataPrincipalId,
-	// verify they are a registered delegate for that principal before proceeding with the search.
-	// Skipped when CallerID is empty (internal/admin calls without a user header).
-	if filters.DataPrincipalID != "" && filters.CallerID != "" {
-		authorized, authErr := consentService.isCallerAuthorizedForPrincipal(
+	// ── Delegate authorization check ─────────────────────────────────────────
+	// When dataPrincipalId is set, the caller must prove they are either the
+	// principal themselves or an active delegate for that principal.
+	//
+	// Failing open (skipping this check when CallerID is empty) would allow any
+	// caller to read another person's consents simply by omitting X-User-ID.
+	//
+	// authorizedConsentIDSet:
+	//   nil  → caller is the principal; no per-consent filter needed.
+	//   non-nil → caller is a delegate; restrict results to these consent IDs.
+	var authorizedConsentIDSet map[string]bool
+	if filters.DataPrincipalID != "" {
+		// Require an explicit caller identity — no anonymous access to another
+		// principal's consents.
+		if filters.CallerID == "" {
+			logger.Warn("dataPrincipalId set but caller identity is missing")
+			return nil, serviceerror.CustomServiceError(
+				ErrorNotAuthorizedForPrincipal,
+				"caller identity is required when dataPrincipalId is set",
+			)
+		}
+
+		authorizedIDs, authErr := consentService.isCallerAuthorizedForPrincipal(
 			ctx, filters.CallerID, filters.DataPrincipalID, filters.OrgID,
 		)
 		if authErr != nil {
@@ -516,7 +545,11 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 				log.String("principal_id", filters.DataPrincipalID))
 			return nil, serviceerror.CustomServiceError(ErrorInternalServerError, authErr.Error())
 		}
-		if !authorized {
+
+		// authorizedIDs == nil  → callerID == principalID (self-access, unrestricted).
+		// authorizedIDs == []   → no valid delegate binding found; deny.
+		// authorizedIDs non-empty → restrict to those specific consent IDs.
+		if authorizedIDs != nil && len(authorizedIDs) == 0 {
 			logger.Warn("Caller not authorized for principal",
 				log.String("caller_id", filters.CallerID),
 				log.String("principal_id", filters.DataPrincipalID))
@@ -526,7 +559,16 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 					filters.CallerID, filters.DataPrincipalID),
 			)
 		}
+		if authorizedIDs != nil {
+			// Build a set for O(1) lookup during post-filter.
+			authorizedConsentIDSet = make(map[string]bool, len(authorizedIDs))
+			for _, id := range authorizedIDs {
+				authorizedConsentIDSet[id] = true
+			}
+		}
+		// authorizedIDs == nil: principal self-access; authorizedConsentIDSet stays nil.
 	}
+	// ── end delegate authorization check ─────────────────────────────────────
 
 	// Step 1: Search consents
 	consentStore := consentService.stores.Consent
@@ -534,6 +576,20 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 	if err != nil {
 		logger.Error("Failed to search consents", log.Error(err))
 		return nil, serviceerror.CustomServiceError(ErrorInternalServerError, err.Error())
+	}
+
+	// Post-filter to the specific consents the delegate is authorized for.
+	// This prevents a delegate binding on one consent from granting visibility
+	// into all consents of the same principal.
+	if authorizedConsentIDSet != nil {
+		filtered := make([]model.Consent, 0, len(consents))
+		for _, c := range consents {
+			if authorizedConsentIDSet[c.ConsentID] {
+				filtered = append(filtered, c)
+			}
+		}
+		total = len(filtered)
+		consents = filtered
 	}
 
 	if len(consents) == 0 {
@@ -1960,7 +2016,6 @@ func (s *consentService) validatePurposes(
 			}
 		}
 
-		// Resolve ALL elements in the purpose (merge requested + missing)
 		// For elements in request: use their approval status and values
 		// For elements not in request: add with isUserApproved=false (user didn't approve)
 		allElements := make([]model.ConsentElementApprovalCreateRequest, 0, len(purposeElementsFromDB))

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -125,6 +125,9 @@ func (consentService *consentService) isCallerAuthorizedForPrincipal(
 		// Load attributes to check whether the delegation period is still active.
 		attributes, err := consentStore.GetAttributesByConsentID(ctx, consentID, orgID)
 		if err != nil {
+			log.GetLogger().WithContext(ctx).Warn("Skipping consent in delegate check due to attribute read error",
+				log.Error(err),
+				log.String("consent_id", consentID))
 			continue
 		}
 		attMap := make(map[string]string)
@@ -143,6 +146,9 @@ func (consentService *consentService) isCallerAuthorizedForPrincipal(
 		// different principal's data.
 		authResources, err := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)
 		if err != nil {
+			log.GetLogger().WithContext(ctx).Warn("Skipping consent in delegate check due to auth resource read error",
+				log.Error(err),
+				log.String("consent_id", consentID))
 			continue
 		}
 		for _, ar := range authResources {
@@ -687,6 +693,8 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 			dataAccessValidityDuration = *consent.DataAccessValidityDuration
 		}
 
+		delegCfg := parseDelegationConfig(attributes)
+
 		detailedResponses = append(detailedResponses, model.ConsentDetailResponse{
 			ID:                         consent.ConsentID,
 			Purposes:                   purposes,
@@ -702,7 +710,7 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 			Attributes:                 attributes,
 			Authorizations:             authorizations,
 			// True when guardian period ends; prompts principal to review inherited consents.
-			IsDelegationExpired: parseDelegationConfig(attributes).IsGuardianConsent() && parseDelegationConfig(attributes).IsExpired(),
+			IsDelegationExpired: delegCfg.IsGuardianConsent() && delegCfg.IsExpired(),
 		})
 	}
 
@@ -1202,7 +1210,13 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 					// Delegate attempting revocation under ANY policy.
 					// Check: delegate must have canRevoke=true on the delegation row for principalID.
 					approvedStatus := string(config.Get().Consent.AuthStatusMappings.ApprovedState)
-					authResources, _ := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)
+					authResources, arErr := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)
+					if arErr != nil {
+						logger.Error("Failed to load auth resources for delegate revocation check",
+							log.Error(arErr),
+							log.String("consent_id", consentID))
+						return nil, serviceerror.CustomServiceError(ErrorInternalServerError, arErr.Error())
+					}
 					callerCanRevoke := false
 					for _, ar := range authResources {
 						if ar.UserID == nil || *ar.UserID != callerID {

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -1122,9 +1122,10 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 	// parseDelegationConfig returns IsGuardianConsent()=false.
 	//
 	// For delegated consents the rules are:
-	//   if delegation expired  → only the principal (now adult) may revoke
-	//   if delegation active   → principal cannot revoke directly (guardian controls)
-	//   if delegation active   → delegate must have canRevoke=true AND policy≠SUBJECT_ONLY
+	//   if delegation expired       → only the principal (now adult) may revoke
+	//   if policy = SUBJECT_ONLY    → only the principal may revoke; delegates blocked
+	//   if policy = ANY             → only delegates with canRevoke=true may revoke; principal blocked
+	//   if policy = BOTH            → both principal and delegates with canRevoke=true may revoke
 	{
 		attributes, attErr := store.GetAttributesByConsentID(ctx, consentID, orgID)
 		if attErr != nil {
@@ -1164,7 +1165,8 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 			} else {
 
 				// SUBJECT_ONLY means only the principal may revoke; delegates are blocked.
-				// ANY means both the principal and permitted delegates may revoke.
+				// ANY means only delegates with canRevoke=true may revoke; principal is blocked.
+				// BOTH means both the principal and delegates with canRevoke=true may revoke.
 				if delegCfg.RevocationPolicy == model.RevocationPolicySubjectOnly {
 					if !isPrincipal {
 						// Delegate blocked by policy.
@@ -1180,18 +1182,28 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 						log.String("principal_id", principalID))
 
 				} else if isPrincipal {
-					// Active guardianship with ANY policy: block the principal from
-					// revoking directly — the guardian controls this consent while active.
-					logger.Warn("Revocation denied: principal cannot revoke under active guardianship",
-						log.String("principal_id", principalID))
-					return nil, serviceerror.CustomServiceError(
-						ErrorRevocationNotPermitted,
-						"the data principal cannot revoke a guardian-controlled consent directly; "+
-							"contact your guardian",
-					)
+					// BOTH policy: both the principal and delegate may revoke.
+					// Used for capable adults — power of attorney, voluntary
+					// assisted delegation, any scenario where the data subject
+					// retains full authority alongside their delegate.
+					if delegCfg.RevocationPolicy == model.RevocationPolicyBoth {
+						logger.Debug("BOTH policy: principal revoking their own consent",
+							log.String("principal_id", principalID))
+						// Fall through — allow revocation to continue.
+					} else {
+						// ANY policy: guardian controls this consent while active.
+						// Principal (e.g. minor child) cannot override the guardian.
+						logger.Warn("Revocation denied: principal cannot revoke under active guardianship",
+							log.String("principal_id", principalID))
+						return nil, serviceerror.CustomServiceError(
+							ErrorRevocationNotPermitted,
+							"the data principal cannot revoke a guardian-controlled consent directly; "+
+								"contact your guardian",
+						)
+					}
 
 				} else {
-					// Delegate attempting revocation under ANY policy.
+					// Delegate attempting revocation under ANY or BOTH policy.
 					// Check: delegate must have canRevoke=true on the delegation row for principalID.
 					approvedStatus := string(config.Get().Consent.AuthStatusMappings.ApprovedState)
 					authResources, arErr := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -762,12 +762,14 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 
 	// ── Delegation-aware modify check ────────────────────────────────────────
 	// For self-consented records this is a no-op (IsGuardianConsent==false).
-	// For delegated consents the rules mirror revocation:
-	//   if delegation expired  → only the principal (now adult) may modify
-	//   if caller == principal → allowed (except under active ANY-policy delegation,
-	//                            where the guardian controls modifications)
-	//   if caller == delegate  → the delegate row must have canModify=true AND
-	//                            onBehalfOf == principalID
+	// For delegated consents the rules are:
+	//   if delegation expired    → only the principal (now adult) may modify
+	//   if caller == principal   → allowed, EXCEPT under active ANY-policy
+	//                              delegation where the guardian controls modifications
+	//   if caller == delegate    → the delegate row must have canModify=true AND
+	//                              onBehalfOf == principalID
+	// Note: Unlike revocation, SUBJECT_ONLY policy does NOT block delegates
+	// from modifying — it only restricts who can revoke.
 	{
 		attributes, attErr := consentStore.GetAttributesByConsentID(ctx, consentID, orgID)
 		if attErr != nil {
@@ -1897,6 +1899,19 @@ func (consentService *consentService) GetConsentDelegates(ctx context.Context, c
 		attMap[a.AttKey] = a.AttValue
 	}
 	delegCfg := parseDelegationConfig(attMap)
+
+	// If this consent has no delegation metadata, return an empty delegate list
+	// rather than scanning auth resources for orphaned onBehalfOf entries.
+	if !delegCfg.IsGuardianConsent() {
+		logger.Info("Consent is not a guardian consent, returning empty delegate list",
+			log.String("consent_id", consentID),
+			log.String("caller_id", callerID))
+		return &model.DelegateListResponse{
+			ConsentID:     consentID,
+			DelegateCount: 0,
+			Delegates:     []model.DelegateInfo{},
+		}, nil
+	}
 
 	// ── Caller authorization check ───────────────────────────────────────
 	// The caller must be the data principal or an active, non-expired delegate.

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -587,7 +587,7 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 		return &model.ConsentDetailSearchResponse{
 			Data: []model.ConsentDetailResponse{},
 			Metadata: model.ConsentSearchMetadata{
-				Total:  0, // Will be 0 because result set is empty
+				Total:  total, // Preserve store-reported total so pagination metadata is correct
 				Limit:  filters.Limit,
 				Offset: filters.Offset,
 				Count:  0,
@@ -768,84 +768,90 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 	//                            where the guardian controls modifications)
 	//   if caller == delegate  → the delegate row must have canModify=true AND
 	//                            onBehalfOf == principalID
-	if req.CallerID != "" {
+	{
 		attributes, attErr := consentStore.GetAttributesByConsentID(ctx, consentID, orgID)
-		if attErr == nil {
-			attMap := make(map[string]string)
-			for _, a := range attributes {
-				attMap[a.AttKey] = a.AttValue
+		if attErr != nil {
+			logger.Error("Failed to load delegation attributes for modify check",
+				log.Error(attErr), log.String("consent_id", consentID))
+			return nil, serviceerror.CustomServiceError(ErrorInternalServerError, attErr.Error())
+		}
+		attMap := make(map[string]string)
+		for _, a := range attributes {
+			attMap[a.AttKey] = a.AttValue
+		}
+		delegCfg := parseDelegationConfig(attMap)
+
+		if delegCfg.IsGuardianConsent() {
+			principalID := delegCfg.PrincipalID
+			callerID := strings.TrimSpace(req.CallerID)
+			if callerID == "" {
+				return nil, serviceerror.CustomServiceError(
+					ErrorNotAuthorizedForPrincipal,
+					"caller identity is required to update a delegated consent",
+				)
 			}
-			delegCfg := parseDelegationConfig(attMap)
+			isPrincipal := callerID == principalID
 
-			if delegCfg.IsGuardianConsent() {
-				principalID := delegCfg.PrincipalID
-				callerID := req.CallerID
-				isPrincipal := callerID == principalID
-
-				if delegCfg.IsExpired() {
-					if !isPrincipal {
-						logger.Warn("Update denied: delegation expired, caller is not principal",
-							log.String("caller_id", callerID),
-							log.String("principal_id", principalID))
-						return nil, serviceerror.CustomServiceError(
-							ErrorDelegationExpired,
-							fmt.Sprintf("delegation for principal '%s' has expired; "+
-								"only the principal may modify this consent", principalID),
-						)
-					}
-				} else if isPrincipal && delegCfg.RevocationPolicy == model.RevocationPolicyAny {
-					// Active ANY-policy delegation: guardian controls modifications too.
-					logger.Warn("Update denied: principal cannot modify under active ANY-policy guardianship",
+			if delegCfg.IsExpired() {
+				if !isPrincipal {
+					logger.Warn("Update denied: delegation expired, caller is not principal",
+						log.String("caller_id", callerID),
 						log.String("principal_id", principalID))
 					return nil, serviceerror.CustomServiceError(
-						ErrorRevocationNotPermitted,
-						"the data principal cannot modify a guardian-controlled consent directly; "+
-							"contact your guardian",
+						ErrorDelegationExpired,
+						fmt.Sprintf("delegation for principal '%s' has expired; "+
+							"only the principal may modify this consent", principalID),
 					)
-				} else if !isPrincipal {
-					// Caller is a (claimed) delegate — must have canModify=true for this principal.
-					approvedStatus := string(config.Get().Consent.AuthStatusMappings.ApprovedState)
-					authResources, arErr := authResourceStore.GetByConsentID(ctx, consentID, orgID)
-					if arErr != nil {
-						logger.Error("Failed to load auth resources for delegate modify check",
-							log.Error(arErr), log.String("consent_id", consentID))
-						return nil, serviceerror.CustomServiceError(ErrorInternalServerError, arErr.Error())
-					}
-					callerCanModify := false
-					for _, ar := range authResources {
-						if ar.UserID == nil || *ar.UserID != callerID {
-							continue
-						}
-						if ar.AuthStatus != approvedStatus {
-							continue
-						}
-						if ar.Resources == nil || *ar.Resources == "" {
-							continue
-						}
-						var res map[string]interface{}
-						if json.Unmarshal([]byte(*ar.Resources), &res) != nil {
-							continue
-						}
-						onBehalfOf, _ := res["onBehalfOf"].(string)
-						if canModify, _ := res["canModify"].(bool); canModify && onBehalfOf == principalID {
-							callerCanModify = true
-							break
-						}
-					}
-					if !callerCanModify {
-						logger.Warn("Update denied: caller lacks canModify permission",
-							log.String("caller_id", callerID))
-						return nil, serviceerror.CustomServiceError(
-							ErrorRevocationNotPermitted,
-							fmt.Sprintf("caller '%s' does not have canModify permission on this consent", callerID),
-						)
-					}
-					logger.Debug("Delegate canModify check passed", log.String("caller_id", callerID))
 				}
+			} else if isPrincipal && delegCfg.RevocationPolicy == model.RevocationPolicyAny {
+				// Active ANY-policy delegation: guardian controls modifications too.
+				logger.Warn("Update denied: principal cannot modify under active ANY-policy guardianship",
+					log.String("principal_id", principalID))
+				return nil, serviceerror.CustomServiceError(
+					ErrorRevocationNotPermitted,
+					"the data principal cannot modify a guardian-controlled consent directly; "+
+						"contact your guardian",
+				)
+			} else if !isPrincipal {
+				// Caller is a (claimed) delegate — must have canModify=true for this principal.
+				approvedStatus := string(config.Get().Consent.AuthStatusMappings.ApprovedState)
+				authResources, arErr := authResourceStore.GetByConsentID(ctx, consentID, orgID)
+				if arErr != nil {
+					logger.Error("Failed to load auth resources for delegate modify check",
+						log.Error(arErr), log.String("consent_id", consentID))
+					return nil, serviceerror.CustomServiceError(ErrorInternalServerError, arErr.Error())
+				}
+				callerCanModify := false
+				for _, ar := range authResources {
+					if ar.UserID == nil || *ar.UserID != callerID {
+						continue
+					}
+					if ar.AuthStatus != approvedStatus {
+						continue
+					}
+					if ar.Resources == nil || *ar.Resources == "" {
+						continue
+					}
+					var res map[string]interface{}
+					if json.Unmarshal([]byte(*ar.Resources), &res) != nil {
+						continue
+					}
+					onBehalfOf, _ := res["onBehalfOf"].(string)
+					if canModify, _ := res["canModify"].(bool); canModify && onBehalfOf == principalID {
+						callerCanModify = true
+						break
+					}
+				}
+				if !callerCanModify {
+					logger.Warn("Update denied: caller lacks canModify permission",
+						log.String("caller_id", callerID))
+					return nil, serviceerror.CustomServiceError(
+						ErrorRevocationNotPermitted,
+						fmt.Sprintf("caller '%s' does not have canModify permission on this consent", callerID),
+					)
+				}
+				logger.Debug("Delegate canModify check passed", log.String("caller_id", callerID))
 			}
-		} else {
-			logger.Warn("Skipped delegation modify check due to attribute read error",
-				log.Error(attErr), log.String("consent_id", consentID))
 		}
 	}
 	// ── end delegation modify check ─────────────────────────────────────────
@@ -1422,7 +1428,8 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 	// ── Delegation-aware audit enrichment ───────────────────────────────────
 	// When the revoker is acting as a delegate for another person, prepend a
 	// structured marker to the Reason field so the audit log answers
-	// "who revoked on whose behalf?" without a schema change.
+	// "who revoked on whose behalf?" without a schema change. The marker is
+	// machine-parseable (delegateAction=...) and human-readable.
 	{
 		attributes, attErr := store.GetAttributesByConsentID(ctx, consentID, orgID)
 		if attErr == nil {

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -760,6 +760,96 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 			fmt.Sprintf("Client '%s' is not authorized to update consent '%s'", clientID, consentID))
 	}
 
+	// ── Delegation-aware modify check ────────────────────────────────────────
+	// For self-consented records this is a no-op (IsGuardianConsent==false).
+	// For delegated consents the rules mirror revocation:
+	//   if delegation expired  → only the principal (now adult) may modify
+	//   if caller == principal → allowed (except under active ANY-policy delegation,
+	//                            where the guardian controls modifications)
+	//   if caller == delegate  → the delegate row must have canModify=true AND
+	//                            onBehalfOf == principalID
+	if req.CallerID != "" {
+		attributes, attErr := consentStore.GetAttributesByConsentID(ctx, consentID, orgID)
+		if attErr == nil {
+			attMap := make(map[string]string)
+			for _, a := range attributes {
+				attMap[a.AttKey] = a.AttValue
+			}
+			delegCfg := parseDelegationConfig(attMap)
+
+			if delegCfg.IsGuardianConsent() {
+				principalID := delegCfg.PrincipalID
+				callerID := req.CallerID
+				isPrincipal := callerID == principalID
+
+				if delegCfg.IsExpired() {
+					if !isPrincipal {
+						logger.Warn("Update denied: delegation expired, caller is not principal",
+							log.String("caller_id", callerID),
+							log.String("principal_id", principalID))
+						return nil, serviceerror.CustomServiceError(
+							ErrorDelegationExpired,
+							fmt.Sprintf("delegation for principal '%s' has expired; "+
+								"only the principal may modify this consent", principalID),
+						)
+					}
+				} else if isPrincipal && delegCfg.RevocationPolicy == model.RevocationPolicyAny {
+					// Active ANY-policy delegation: guardian controls modifications too.
+					logger.Warn("Update denied: principal cannot modify under active ANY-policy guardianship",
+						log.String("principal_id", principalID))
+					return nil, serviceerror.CustomServiceError(
+						ErrorRevocationNotPermitted,
+						"the data principal cannot modify a guardian-controlled consent directly; "+
+							"contact your guardian",
+					)
+				} else if !isPrincipal {
+					// Caller is a (claimed) delegate — must have canModify=true for this principal.
+					approvedStatus := string(config.Get().Consent.AuthStatusMappings.ApprovedState)
+					authResources, arErr := authResourceStore.GetByConsentID(ctx, consentID, orgID)
+					if arErr != nil {
+						logger.Error("Failed to load auth resources for delegate modify check",
+							log.Error(arErr), log.String("consent_id", consentID))
+						return nil, serviceerror.CustomServiceError(ErrorInternalServerError, arErr.Error())
+					}
+					callerCanModify := false
+					for _, ar := range authResources {
+						if ar.UserID == nil || *ar.UserID != callerID {
+							continue
+						}
+						if ar.AuthStatus != approvedStatus {
+							continue
+						}
+						if ar.Resources == nil || *ar.Resources == "" {
+							continue
+						}
+						var res map[string]interface{}
+						if json.Unmarshal([]byte(*ar.Resources), &res) != nil {
+							continue
+						}
+						onBehalfOf, _ := res["onBehalfOf"].(string)
+						if canModify, _ := res["canModify"].(bool); canModify && onBehalfOf == principalID {
+							callerCanModify = true
+							break
+						}
+					}
+					if !callerCanModify {
+						logger.Warn("Update denied: caller lacks canModify permission",
+							log.String("caller_id", callerID))
+						return nil, serviceerror.CustomServiceError(
+							ErrorRevocationNotPermitted,
+							fmt.Sprintf("caller '%s' does not have canModify permission on this consent", callerID),
+						)
+					}
+					logger.Debug("Delegate canModify check passed", log.String("caller_id", callerID))
+				}
+			}
+		} else {
+			logger.Warn("Skipped delegation modify check due to attribute read error",
+				log.Error(attErr), log.String("consent_id", consentID))
+		}
+	}
+	// ── end delegation modify check ─────────────────────────────────────────
+
 	currentTime := utils.GetCurrentTimeMillis()
 	previousStatus := existing.CurrentStatus
 
@@ -868,6 +958,78 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 			})
 		}
 	}
+
+	// ── Convert-to-self-consent ─────────────────────────────────────────
+	// When a delegated consent's guardian period has expired, the principal
+	// can convert it to a self-consent by stripping all delegation metadata.
+	// This lets the now-adult child (or recovered patient, etc.) take
+	// ownership of the existing consent record without creating a duplicate.
+	if req.ConvertToSelfConsent {
+		convAttrs, convErr := consentStore.GetAttributesByConsentID(ctx, consentID, orgID)
+		if convErr != nil {
+			logger.Error("Failed to load attributes for conversion check",
+				log.Error(convErr), log.String("consent_id", consentID))
+			return nil, serviceerror.CustomServiceError(ErrorInternalServerError, convErr.Error())
+		}
+		convMap := make(map[string]string)
+		for _, a := range convAttrs {
+			convMap[a.AttKey] = a.AttValue
+		}
+		convDelegCfg := parseDelegationConfig(convMap)
+
+		if !convDelegCfg.IsGuardianConsent() {
+			return nil, serviceerror.CustomServiceError(ErrorValidationFailed,
+				"convertToSelfConsent is only valid on delegated consents")
+		}
+		if !convDelegCfg.IsExpired() {
+			return nil, serviceerror.CustomServiceError(ErrorValidationFailed,
+				"delegation must be expired before the principal can convert to self-consent")
+		}
+		if req.CallerID != convDelegCfg.PrincipalID {
+			return nil, serviceerror.CustomServiceError(ErrorRevocationNotPermitted,
+				fmt.Sprintf("only the principal '%s' can convert this consent to self-consent",
+					convDelegCfg.PrincipalID))
+		}
+
+		// Strip all 4 delegation attributes in the transaction
+		delegationKeys := []string{
+			model.AttrDelegationType,
+			model.AttrDelegationPrincipalID,
+			model.AttrGuardianValidUntil,
+			model.AttrGuardianRevocationPolicy,
+		}
+		for _, key := range delegationKeys {
+			k := key // capture for closure
+			queries = append(queries, func(tx dbmodel.TxInterface) error {
+				return consentStore.DeleteAttributeByKey(tx, consentID, k, orgID)
+			})
+		}
+
+		// Audit the conversion
+		convAuditID := utils.GenerateUUID()
+		convReason := fmt.Sprintf(
+			"[conversionToSelfConsent=true; actor=%s; fromDelegationType=%s; delegationExpired=true]",
+			req.CallerID, convDelegCfg.Type)
+		convAudit := &model.ConsentStatusAudit{
+			StatusAuditID:  convAuditID,
+			ConsentID:      consentID,
+			CurrentStatus:  existing.CurrentStatus,
+			ActionTime:     utils.GetCurrentTimeMillis(),
+			Reason:         &convReason,
+			ActionBy:       &req.CallerID,
+			PreviousStatus: &existing.CurrentStatus,
+			OrgID:          orgID,
+		}
+		queries = append(queries, func(tx dbmodel.TxInterface) error {
+			return consentStore.CreateStatusAudit(tx, convAudit)
+		})
+
+		logger.Info("Converting delegated consent to self-consent",
+			log.String("consent_id", consentID),
+			log.String("principal_id", convDelegCfg.PrincipalID),
+			log.String("former_delegation_type", convDelegCfg.Type))
+	}
+	// ── end convert-to-self-consent ─────────────────────────────────────
 
 	// Update authorization resources if provided
 	if updateReq.AuthResources != nil {
@@ -1256,6 +1418,47 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 	// Create audit entry
 	auditID := utils.GenerateUUID()
 	reason := req.RevocationReason
+
+	// ── Delegation-aware audit enrichment ───────────────────────────────────
+	// When the revoker is acting as a delegate for another person, prepend a
+	// structured marker to the Reason field so the audit log answers
+	// "who revoked on whose behalf?" without a schema change.
+	{
+		attributes, attErr := store.GetAttributesByConsentID(ctx, consentID, orgID)
+		if attErr == nil {
+			attMap := make(map[string]string)
+			for _, a := range attributes {
+				attMap[a.AttKey] = a.AttValue
+			}
+			delegCfg := parseDelegationConfig(attMap)
+			if delegCfg.IsGuardianConsent() && req.ActionBy != delegCfg.PrincipalID {
+				// Delegate is acting — record the relationship.
+				marker := fmt.Sprintf(
+					"[delegateAction=true; actor=%s; onBehalfOf=%s; delegationType=%s]",
+					req.ActionBy, delegCfg.PrincipalID, delegCfg.Type,
+				)
+				if reason == "" {
+					reason = marker
+				} else {
+					reason = marker + " " + reason
+				}
+			} else if delegCfg.IsGuardianConsent() && req.ActionBy == delegCfg.PrincipalID {
+				// Principal acting on their own consent under a delegation record
+				// (e.g., now-adult child revoking after guardian.valid_until).
+				marker := fmt.Sprintf(
+					"[principalAction=true; actor=%s; delegationExpired=%t]",
+					req.ActionBy, delegCfg.IsExpired(),
+				)
+				if reason == "" {
+					reason = marker
+				} else {
+					reason = marker + " " + reason
+				}
+			}
+		}
+	}
+	// ── end delegation audit enrichment ─────────────────────────────────────
+
 	audit := &model.ConsentStatusAudit{
 		StatusAuditID:  auditID,
 		ConsentID:      consentID,

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -1085,38 +1085,61 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 	//   if delegation active   → delegate must have canRevoke=true AND policy≠SUBJECT_ONLY
 	{
 		attributes, attErr := store.GetAttributesByConsentID(ctx, consentID, orgID)
-		if attErr == nil {
-			attMap := make(map[string]string)
-			for _, a := range attributes {
-				attMap[a.AttKey] = a.AttValue
-			}
-			delegCfg := parseDelegationConfig(attMap)
+		if attErr != nil {
+			logger.Error("Failed to load delegation attributes for revocation",
+				log.Error(attErr),
+				log.String("consent_id", consentID))
+			return nil, serviceerror.CustomServiceError(ErrorInternalServerError, attErr.Error())
+		}
+		attMap := make(map[string]string)
+		for _, a := range attributes {
+			attMap[a.AttKey] = a.AttValue
+		}
+		delegCfg := parseDelegationConfig(attMap)
 
-			if delegCfg.IsGuardianConsent() {
-				principalID := delegCfg.PrincipalID
-				callerID := req.ActionBy
-				isPrincipal := callerID == principalID
+		if delegCfg.IsGuardianConsent() {
+			principalID := delegCfg.PrincipalID
+			callerID := req.ActionBy
+			isPrincipal := callerID == principalID
 
-				if delegCfg.IsExpired() {
-					// delegation ended (e.g., child is now an adult).
-					// Only the principal has authority; delegates are locked out.
+			if delegCfg.IsExpired() {
+				// delegation ended (e.g., child is now an adult).
+				// Only the principal has authority; delegates are locked out.
+				if !isPrincipal {
+					logger.Warn("Revocation denied: delegation expired, caller is not principal",
+						log.String("caller_id", callerID),
+						log.String("principal_id", principalID))
+					return nil, serviceerror.CustomServiceError(
+						ErrorDelegationExpired,
+						fmt.Sprintf("delegation for principal '%s' has expired; "+
+							"only the principal may revoke this consent", principalID),
+					)
+				}
+				// Principal is now an adult — allow revocation to continue.
+				logger.Debug("Delegation expired; principal revoking their own consent",
+					log.String("principal_id", principalID))
+
+			} else {
+
+				// SUBJECT_ONLY means only the principal may revoke; delegates are blocked.
+				// ANY means both the principal and permitted delegates may revoke.
+				if delegCfg.RevocationPolicy == model.RevocationPolicySubjectOnly {
 					if !isPrincipal {
-						logger.Warn("Revocation denied: delegation expired, caller is not principal",
-							log.String("caller_id", callerID),
-							log.String("principal_id", principalID))
+						// Delegate blocked by policy.
+						logger.Warn("Revocation denied: policy is SUBJECT_ONLY",
+							log.String("caller_id", callerID))
 						return nil, serviceerror.CustomServiceError(
-							ErrorDelegationExpired,
-							fmt.Sprintf("delegation for principal '%s' has expired; "+
-								"only the principal may revoke this consent", principalID),
+							ErrorRevocationNotPermitted,
+							"revocation policy is SUBJECT_ONLY; only the data principal may revoke",
 						)
 					}
-					// Principal is now an adult — allow revocation to continue.
-					logger.Debug("Delegation expired; principal revoking their own consent",
+					// Principal is explicitly allowed under SUBJECT_ONLY — fall through.
+					logger.Debug("SUBJECT_ONLY policy: principal revoking their own consent",
 						log.String("principal_id", principalID))
 
 				} else if isPrincipal {
-					// active guardianship: block the principal from revoking directly.
-					// The guardian (parent/carer) controls this consent while it is active.
+					// Active guardianship with ANY policy: block the principal from
+					// revoking directly — the guardian controls this consent while active.
 					logger.Warn("Revocation denied: principal cannot revoke under active guardianship",
 						log.String("principal_id", principalID))
 					return nil, serviceerror.CustomServiceError(
@@ -1126,17 +1149,8 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 					)
 
 				} else {
-					// a delegate is attempting revocation while delegation is active.
-					// Check 1: revocation policy.
-					if delegCfg.RevocationPolicy == model.RevocationPolicySubjectOnly {
-						logger.Warn("Revocation denied: policy is SUBJECT_ONLY",
-							log.String("caller_id", callerID))
-						return nil, serviceerror.CustomServiceError(
-							ErrorRevocationNotPermitted,
-							"revocation policy is SUBJECT_ONLY; only the data principal may revoke",
-						)
-					}
-					// Check 2: delegate must have canRevoke=true in their auth resource.
+					// Delegate attempting revocation under ANY policy.
+					// Check: delegate must have canRevoke=true on the delegation row for principalID.
 					approvedStatus := string(config.Get().Consent.AuthStatusMappings.ApprovedState)
 					authResources, _ := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)
 					callerCanRevoke := false
@@ -1154,7 +1168,10 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 						if json.Unmarshal([]byte(*ar.Resources), &res) != nil {
 							continue
 						}
-						if canRevoke, _ := res["canRevoke"].(bool); canRevoke {
+						// principalID — prevents an unrelated canRevoke=true row from
+						// accidentally granting revoke rights over a different principal.
+						onBehalfOf, _ := res["onBehalfOf"].(string)
+						if canRevoke, _ := res["canRevoke"].(bool); canRevoke && onBehalfOf == principalID {
 							callerCanRevoke = true
 							break
 						}

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	authmodel "github.com/wso2/openfgc/internal/authresource/model"
 	"github.com/wso2/openfgc/internal/consent/model"
@@ -67,17 +68,24 @@ func newConsentService(registry *stores.StoreRegistry) ConsentService {
 // and returns a DelegationConfig. Returns an empty DelegationConfig (IsGuardianConsent=false)
 // when no delegation.type attribute is present.
 func parseDelegationConfig(attMap map[string]string) model.DelegationConfig {
+	delegationType := strings.TrimSpace(attMap[model.AttrDelegationType])
+	principalID := strings.TrimSpace(attMap[model.AttrDelegationPrincipalID])
+	revocationPolicy := model.RevocationPolicy(strings.TrimSpace(attMap[model.AttrGuardianRevocationPolicy]))
+
 	validUntil := int64(0)
-	if s := attMap[model.AttrGuardianValidUntil]; s != "" {
+	if s := strings.TrimSpace(attMap[model.AttrGuardianValidUntil]); s != "" {
 		if ts, err := strconv.ParseInt(s, 10, 64); err == nil {
 			validUntil = ts
+		} else {
+			validUntil = 0
 		}
 	}
+
 	return model.DelegationConfig{
-		Type:             attMap[model.AttrDelegationType],
-		PrincipalID:      attMap[model.AttrDelegationPrincipalID],
+		Type:             delegationType,
+		PrincipalID:      principalID,
 		ValidUntil:       validUntil,
-		RevocationPolicy: model.RevocationPolicy(attMap[model.AttrGuardianRevocationPolicy]),
+		RevocationPolicy: revocationPolicy,
 	}
 }
 
@@ -547,8 +555,11 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 			return nil, serviceerror.CustomServiceError(ErrorInternalServerError, authErr.Error())
 		}
 
-		// authorizedIDs == []   → no valid delegate binding found; deny.
-		if authorizedIDs != nil && len(authorizedIDs) == 0 {
+		if authorizedIDs == nil {
+			// callerID == principalID — unrestricted self-access.
+			// Clear DataPrincipalID so the store does not filter by delegation attribute.
+			filters.DataPrincipalID = ""
+		} else if len(authorizedIDs) == 0 {
 			logger.Warn("Caller not authorized for principal",
 				log.String("caller_id", filters.CallerID),
 				log.String("principal_id", filters.DataPrincipalID))
@@ -557,10 +568,8 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 				fmt.Sprintf("caller '%s' is not a registered delegate for principal '%s'",
 					filters.CallerID, filters.DataPrincipalID),
 			)
-		}
-
-		// Pass the authorized IDs directly to the DB filters so pagination works natively
-		if authorizedIDs != nil {
+		} else {
+			// Pass the authorized IDs directly to the DB filters so pagination works natively
 			filters.AuthorizedConsentIDs = authorizedIDs
 		}
 	}

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	authmodel "github.com/wso2/openfgc/internal/authresource/model"
 	"github.com/wso2/openfgc/internal/consent/model"
@@ -43,6 +44,9 @@ type ConsentService interface {
 	RevokeConsent(ctx context.Context, consentID, orgID string, req model.ConsentRevokeRequest) (*model.ConsentRevokeResponse, *serviceerror.ServiceError)
 	ValidateConsent(ctx context.Context, req model.ValidateRequest, orgID string) (*model.ValidateResponse, *serviceerror.ServiceError)
 	SearchConsentsByAttribute(ctx context.Context, key, value, orgID string) (*model.ConsentAttributeSearchResponse, *serviceerror.ServiceError)
+	// GetConsentDelegates returns all registered delegates for a single consent.
+	// Reads from CONSENT_AUTH_RESOURCE rows (RESOURCES JSON blob) and CONSENT_ATTRIBUTE rows.
+	GetConsentDelegates(ctx context.Context, consentID, orgID string) (*model.DelegateListResponse, *serviceerror.ServiceError)
 }
 
 // consentService implements the ConsentService interface
@@ -56,6 +60,105 @@ func newConsentService(registry *stores.StoreRegistry) ConsentService {
 		stores: registry,
 	}
 }
+
+// ── Delegation helpers ────────────────────────────────────────────────────────
+
+// parseDelegationConfig reads delegation attributes from a consent's attribute map
+// and returns a DelegationConfig. Returns an empty DelegationConfig (IsGuardianConsent=false)
+// when no delegation.type attribute is present.
+func parseDelegationConfig(attMap map[string]string) model.DelegationConfig {
+	validUntil := int64(0)
+	if s := attMap[model.AttrGuardianValidUntil]; s != "" {
+		if ts, err := strconv.ParseInt(s, 10, 64); err == nil {
+			validUntil = ts
+		}
+	}
+	return model.DelegationConfig{
+		Type:             attMap[model.AttrDelegationType],
+		PrincipalID:      attMap[model.AttrDelegationPrincipalID],
+		ValidUntil:       validUntil,
+		RevocationPolicy: model.RevocationPolicy(attMap[model.AttrGuardianRevocationPolicy]),
+	}
+}
+
+// isCallerAuthorizedForPrincipal returns true when callerID is allowed to read or
+// act on consents where principalID is the data subject
+//
+// Access is granted when:
+//   - callerID == principalID  (people can always access their own data), OR
+//   - callerID has an APPROVED auth resource row on any consent whose
+//     delegation.principal_id == principalID, with onBehalfOf == principalID
+//     in the RESOURCES JSON blob, AND the delegation has not yet expired.
+//
+// Uses FindConsentIDsByAttribute (queries CONSENT_ATTRIBUTE)
+func (consentService *consentService) isCallerAuthorizedForPrincipal(
+	ctx context.Context,
+	callerID, principalID, orgID string,
+) (bool, error) {
+	// Principals can always access their own data.
+	if callerID == principalID {
+		return true, nil
+	}
+
+	// Find all consents where this person is the data subject.
+	// FindConsentIDsByAttribute queries CONSENT_ATTRIBUTE directly.
+	consentStore := consentService.stores.Consent
+	consentIDs, err := consentStore.FindConsentIDsByAttribute(
+		ctx, model.AttrDelegationPrincipalID, principalID, orgID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to look up delegated consents: %w", err)
+	}
+	if len(consentIDs) == 0 {
+		return false, nil
+	}
+
+	approvedStatus := string(config.Get().Consent.AuthStatusMappings.ApprovedState)
+
+	for _, consentID := range consentIDs {
+		// Load attributes to check whether delegation has expired
+		attributes, err := consentStore.GetAttributesByConsentID(ctx, consentID, orgID)
+		if err != nil {
+			continue
+		}
+		attMap := make(map[string]string)
+		for _, a := range attributes {
+			attMap[a.AttKey] = a.AttValue
+		}
+		cfg := parseDelegationConfig(attMap)
+		if cfg.IsExpired() {
+			// Delegation period ended — this delegate's rights have lapsed.
+			continue
+		}
+
+		// Check whether callerID has an active auth resource with onBehalfOf = principalID.
+		authResources, err := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)
+		if err != nil {
+			continue
+		}
+		for _, ar := range authResources {
+			if ar.AuthStatus != approvedStatus {
+				continue
+			}
+			if ar.UserID == nil || *ar.UserID != callerID {
+				continue
+			}
+			if ar.Resources == nil || *ar.Resources == "" {
+				continue
+			}
+			var res map[string]interface{}
+			if json.Unmarshal([]byte(*ar.Resources), &res) != nil {
+				continue
+			}
+			if onBehalfOf, _ := res["onBehalfOf"].(string); onBehalfOf == principalID {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// ── end delegation helpers ────────────────────────────────────────────────────
 
 // CreateConsent creates a new consent with all related entities in a single transaction
 func (consentService *consentService) CreateConsent(ctx context.Context, req model.ConsentAPIRequest, clientID, orgID string) (*model.ConsentResponse, *serviceerror.ServiceError) {
@@ -72,6 +175,9 @@ func (consentService *consentService) CreateConsent(ctx context.Context, req mod
 	}
 
 	logger.Debug("initial request validation successful")
+
+	// Note: ValidateDelegationAttributes is called in the handler before this method
+	// is reached, so delegation attribute validation has already been applied.
 
 	// Convert API request to internal format
 	createReq, err := req.ToConsentCreateRequest()
@@ -396,6 +502,32 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 		filters.Offset = 0
 	}
 
+	// When a caller requests another person's consents via dataPrincipalId,
+	// verify they are a registered delegate for that principal before proceeding with the search.
+	// Skipped when CallerID is empty (internal/admin calls without a user header).
+	if filters.DataPrincipalID != "" && filters.CallerID != "" {
+		authorized, authErr := consentService.isCallerAuthorizedForPrincipal(
+			ctx, filters.CallerID, filters.DataPrincipalID, filters.OrgID,
+		)
+		if authErr != nil {
+			logger.Error("Failed to verify delegate authorization",
+				log.Error(authErr),
+				log.String("caller_id", filters.CallerID),
+				log.String("principal_id", filters.DataPrincipalID))
+			return nil, serviceerror.CustomServiceError(ErrorInternalServerError, authErr.Error())
+		}
+		if !authorized {
+			logger.Warn("Caller not authorized for principal",
+				log.String("caller_id", filters.CallerID),
+				log.String("principal_id", filters.DataPrincipalID))
+			return nil, serviceerror.CustomServiceError(
+				ErrorNotAuthorizedForPrincipal,
+				fmt.Sprintf("caller '%s' is not a registered delegate for principal '%s'",
+					filters.CallerID, filters.DataPrincipalID),
+			)
+		}
+	}
+
 	// Step 1: Search consents
 	consentStore := consentService.stores.Consent
 	consents, total, err := consentStore.Search(ctx, filters)
@@ -517,6 +649,10 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 			DataAccessValidityDuration: dataAccessValidityDuration,
 			Attributes:                 attributes,
 			Authorizations:             authorizations,
+			// DelegationExpired is true when the guardian period has passed.
+			// The data principal (now adult/capable) holds full authority.
+			// The portal uses this flag to prompt the principal to review inherited consents.
+			DelegationExpired: parseDelegationConfig(attributes).IsGuardianConsent() && parseDelegationConfig(attributes).IsExpired(),
 		})
 	}
 
@@ -939,6 +1075,105 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 		return nil, serviceerror.CustomServiceError(ErrorConsentAlreadyRevoked, fmt.Sprintf("Consent with ID '%s' is already revoked", consentID))
 	}
 
+	// ── Delegation-aware revocation check ────────────
+	// For normal self-consented records this entire block is a no-op because
+	// parseDelegationConfig returns IsGuardianConsent()=false.
+	//
+	// For delegated consents the rules are:
+	//   if delegation expired  → only the principal (now adult) may revoke
+	//   if delegation active   → principal cannot revoke directly (guardian controls)
+	//   if delegation active   → delegate must have canRevoke=true AND policy≠SUBJECT_ONLY
+	{
+		attributes, attErr := store.GetAttributesByConsentID(ctx, consentID, orgID)
+		if attErr == nil {
+			attMap := make(map[string]string)
+			for _, a := range attributes {
+				attMap[a.AttKey] = a.AttValue
+			}
+			delegCfg := parseDelegationConfig(attMap)
+
+			if delegCfg.IsGuardianConsent() {
+				principalID := delegCfg.PrincipalID
+				callerID := req.ActionBy
+				isPrincipal := callerID == principalID
+
+				if delegCfg.IsExpired() {
+					// delegation ended (e.g., child is now an adult).
+					// Only the principal has authority; delegates are locked out.
+					if !isPrincipal {
+						logger.Warn("Revocation denied: delegation expired, caller is not principal",
+							log.String("caller_id", callerID),
+							log.String("principal_id", principalID))
+						return nil, serviceerror.CustomServiceError(
+							ErrorDelegationExpired,
+							fmt.Sprintf("delegation for principal '%s' has expired; "+
+								"only the principal may revoke this consent", principalID),
+						)
+					}
+					// Principal is now an adult — allow revocation to continue.
+					logger.Debug("Delegation expired; principal revoking their own consent",
+						log.String("principal_id", principalID))
+
+				} else if isPrincipal {
+					// active guardianship: block the principal from revoking directly.
+					// The guardian (parent/carer) controls this consent while it is active.
+					logger.Warn("Revocation denied: principal cannot revoke under active guardianship",
+						log.String("principal_id", principalID))
+					return nil, serviceerror.CustomServiceError(
+						ErrorRevocationNotPermitted,
+						"the data principal cannot revoke a guardian-controlled consent directly; "+
+							"contact your guardian",
+					)
+
+				} else {
+					// a delegate is attempting revocation while delegation is active.
+					// Check 1: revocation policy.
+					if delegCfg.RevocationPolicy == model.RevocationPolicySubjectOnly {
+						logger.Warn("Revocation denied: policy is SUBJECT_ONLY",
+							log.String("caller_id", callerID))
+						return nil, serviceerror.CustomServiceError(
+							ErrorRevocationNotPermitted,
+							"revocation policy is SUBJECT_ONLY; only the data principal may revoke",
+						)
+					}
+					// Check 2: delegate must have canRevoke=true in their auth resource.
+					approvedStatus := string(config.Get().Consent.AuthStatusMappings.ApprovedState)
+					authResources, _ := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)
+					callerCanRevoke := false
+					for _, ar := range authResources {
+						if ar.UserID == nil || *ar.UserID != callerID {
+							continue
+						}
+						if ar.AuthStatus != approvedStatus {
+							continue
+						}
+						if ar.Resources == nil || *ar.Resources == "" {
+							continue
+						}
+						var res map[string]interface{}
+						if json.Unmarshal([]byte(*ar.Resources), &res) != nil {
+							continue
+						}
+						if canRevoke, _ := res["canRevoke"].(bool); canRevoke {
+							callerCanRevoke = true
+							break
+						}
+					}
+					if !callerCanRevoke {
+						logger.Warn("Revocation denied: caller lacks canRevoke permission",
+							log.String("caller_id", callerID))
+						return nil, serviceerror.CustomServiceError(
+							ErrorRevocationNotPermitted,
+							fmt.Sprintf("caller '%s' does not have canRevoke permission on this consent", callerID),
+						)
+					}
+					logger.Debug("Delegate canRevoke check passed", log.String("caller_id", callerID))
+				}
+			}
+		}
+	}
+	// ── end delegation revocation check ──────────────────────────────────────────
+
 	currentTime := utils.GetCurrentTimeMillis()
 
 	// Create audit entry
@@ -1343,6 +1578,95 @@ func buildConsentResponse(
 	}
 }
 
+// GetConsentDelegates returns all registered delegates for a consent.
+// It reads CONSENT_AUTH_RESOURCE rows (RESOURCES JSON blob for per-delegate flags)
+// and CONSENT_ATTRIBUTE rows (for delegation.principal_id, guardian.valid_until, etc.).
+
+func (consentService *consentService) GetConsentDelegates(ctx context.Context, consentID, orgID string) (*model.DelegateListResponse, *serviceerror.ServiceError) {
+	logger := log.GetLogger().WithContext(ctx)
+	logger.Info("Getting consent delegates",
+		log.String("consent_id", consentID),
+		log.String("org_id", orgID))
+
+	// Verify consent exists.
+	store := consentService.stores.Consent
+	existing, err := store.GetByID(ctx, consentID, orgID)
+	if err != nil {
+		return nil, serviceerror.CustomServiceError(ErrorInternalServerError, err.Error())
+	}
+	if existing == nil {
+		return nil, serviceerror.CustomServiceError(ErrorConsentNotFound,
+			fmt.Sprintf("consent with ID '%s' not found", consentID))
+	}
+
+	// Load attributes to read delegation metadata.
+	attributes, err := store.GetAttributesByConsentID(ctx, consentID, orgID)
+	if err != nil {
+		return nil, serviceerror.CustomServiceError(ErrorInternalServerError, err.Error())
+	}
+	attMap := make(map[string]string)
+	for _, a := range attributes {
+		attMap[a.AttKey] = a.AttValue
+	}
+	delegCfg := parseDelegationConfig(attMap)
+
+	// Load all auth resource rows for this consent.
+	authResources, err := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)
+	if err != nil {
+		return nil, serviceerror.CustomServiceError(ErrorInternalServerError, err.Error())
+	}
+
+	// Build DelegateInfo list from auth resources that carry onBehalfOf in RESOURCES.
+	delegates := make([]model.DelegateInfo, 0)
+	for _, ar := range authResources {
+		if ar.Resources == nil || *ar.Resources == "" {
+			continue
+		}
+		var res map[string]interface{}
+		if json.Unmarshal([]byte(*ar.Resources), &res) != nil {
+			continue
+		}
+		onBehalfOf, _ := res["onBehalfOf"].(string)
+		if onBehalfOf == "" {
+			continue // not a delegate auth resource
+		}
+		userID := ""
+		if ar.UserID != nil {
+			userID = *ar.UserID
+		}
+		canRevoke, _ := res["canRevoke"].(bool)
+		canModify, _ := res["canModify"].(bool)
+		delegationType, _ := res["delegationType"].(string)
+
+		delegates = append(delegates, model.DelegateInfo{
+			AuthID:         ar.AuthID,
+			UserID:         userID,
+			DelegationType: delegationType,
+			Status:         ar.AuthStatus,
+			CanRevoke:      canRevoke,
+			CanModify:      canModify,
+			OnBehalfOf:     onBehalfOf,
+			UpdatedTime:    ar.UpdatedTime,
+		})
+	}
+
+	response := &model.DelegateListResponse{
+		ConsentID:           consentID,
+		DataPrincipalID:     delegCfg.PrincipalID,
+		RevocationPolicy:    string(delegCfg.RevocationPolicy),
+		ValidUntil:          delegCfg.ValidUntil,
+		IsDelegationExpired: delegCfg.IsExpired(),
+		DelegateCount:       len(delegates),
+		Delegates:           delegates,
+	}
+
+	logger.Info("Consent delegates retrieved",
+		log.Int("delegate_count", len(delegates)),
+		log.String("consent_id", consentID))
+
+	return response, nil
+}
+
 // SearchConsentsByAttribute searches for consents by attribute key and optionally value
 // If value is empty, it searches by key only
 func (consentService *consentService) SearchConsentsByAttribute(ctx context.Context, key, value, orgID string) (*model.ConsentAttributeSearchResponse, *serviceerror.ServiceError) {
@@ -1517,7 +1841,7 @@ func (s *consentService) getResolvedConsentPurposes(
 // This validation is called AFTER purpose resolution from database, so it checks the
 // complete set of elements (including auto-filled ones), not just what user provided.
 // This prevents an element from being assigned to multiple purposes, which would create
-// ambiguity in consent management.
+
 func (s *consentService) validateNoDuplicateElementsAcrossPurposes(
 	purposes []model.ConsentPurposeCreateRequest,
 ) error {
@@ -1549,7 +1873,7 @@ func (s *consentService) validateNoDuplicateElementsAcrossPurposes(
 // 3. Validates that user-provided elements belong to their respective purposes
 // 4. Resolves missing purposes (not in request) with isUserApproved=false
 // 5. Validates no duplicate elements exist across all resolved elements in purposes
-// Returns fully enriched purposes ready for database insertion.
+
 func (s *consentService) validatePurposes(
 	ctx context.Context,
 	purposes []model.ConsentPurposeCreateRequest,
@@ -1558,7 +1882,7 @@ func (s *consentService) validatePurposes(
 
 	logger := log.GetLogger().WithContext(ctx)
 
-	// Step 1: Resolve purposes and get their full definitions from database
+	// Resolve purposes and get their full definitions from database
 	resolvedPurposes := make([]model.ConsentPurposeCreateRequest, 0, len(purposes))
 	purposeStore := s.stores.ConsentPurpose
 
@@ -1586,7 +1910,7 @@ func (s *consentService) validatePurposes(
 			log.String("purpose_name", requestedIndividualPurpose.PurposeName),
 			log.String("purpose_id", retrievedPurpose.ID))
 
-		// Step 2: Get ALL elements defined in this purpose.
+		// Get ALL elements defined in this purpose.
 		// This gives us the complete list of elements with their IDs, names, and mandatory flags
 		purposeElementsFromDB := retrievedPurpose.Elements
 
@@ -1595,14 +1919,14 @@ func (s *consentService) validatePurposes(
 			log.Int("total_elements", len(purposeElementsFromDB)),
 			log.Int("requested_elements", len(requestedIndividualPurpose.Elements)))
 
-		// Step 3: Create lookup map for elements provided in the request
+		// Create lookup map for elements provided in the request
 		// Key: element name, Value: approval details from request
 		requestedElementsMap := make(map[string]model.ConsentElementApprovalCreateRequest)
 		for _, requestedElements := range requestedIndividualPurpose.Elements {
 			requestedElementsMap[requestedElements.ElementName] = requestedElements
 		}
 
-		// Step 4: Create lookup map for valid elements from database
+		// Create lookup map for valid elements from database
 		// This is used to validate that user-provided elements actually belong to this purpose
 		validElementNames := make(map[string]bool)
 		for _, elem := range purposeElementsFromDB {
@@ -1619,7 +1943,7 @@ func (s *consentService) validatePurposes(
 			}
 		}
 
-		// Step 6: Resolve ALL elements in the purpose (merge requested + missing)
+		// Resolve ALL elements in the purpose (merge requested + missing)
 		// For elements in request: use their approval status and values
 		// For elements not in request: add with isUserApproved=false (user didn't approve)
 		allElements := make([]model.ConsentElementApprovalCreateRequest, 0, len(purposeElementsFromDB))
@@ -1656,7 +1980,7 @@ func (s *consentService) validatePurposes(
 		})
 	}
 
-	// Step 7: Validate no duplicate elements across ALL resolved purposes
+	// Validate no duplicate elements across ALL resolved purposes
 	// This check happens AFTER resolution because we now have the complete picture
 	// of all elements across all purposes (including auto-filled ones)
 	if err := s.validateNoDuplicateElementsAcrossPurposes(resolvedPurposes); err != nil {

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -810,7 +810,7 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 				logger.Warn("Update denied: principal cannot modify under active ANY-policy guardianship",
 					log.String("principal_id", principalID))
 				return nil, serviceerror.CustomServiceError(
-					ErrorRevocationNotPermitted,
+					ErrorModificationNotPermitted,
 					"the data principal cannot modify a guardian-controlled consent directly; "+
 						"contact your guardian",
 				)
@@ -848,7 +848,7 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 					logger.Warn("Update denied: caller lacks canModify permission",
 						log.String("caller_id", callerID))
 					return nil, serviceerror.CustomServiceError(
-						ErrorRevocationNotPermitted,
+						ErrorModificationNotPermitted,
 						fmt.Sprintf("caller '%s' does not have canModify permission on this consent", callerID),
 					)
 				}

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -1827,6 +1827,17 @@ func (consentService *consentService) GetConsentDelegates(ctx context.Context, c
 	if delegCfg.IsGuardianConsent() {
 		callerID = strings.TrimSpace(callerID)
 		principalID := delegCfg.PrincipalID
+		// Block expired delegates from viewing delegate list.
+		if delegCfg.IsExpired() && callerID != principalID {
+			logger.Warn("GetConsentDelegates denied: delegation expired, caller is not principal",
+				log.String("caller_id", callerID),
+				log.String("principal_id", principalID))
+			return nil, serviceerror.CustomServiceError(
+				ErrorDelegationExpired,
+				fmt.Sprintf("delegation for principal '%s' has expired; only the principal may view delegates",
+					principalID),
+			)
+		}
 		if callerID != principalID {
 			// Caller is not the principal — check if they are an active delegate.
 			authResources, arErr := consentService.stores.AuthResource.GetByConsentID(ctx, consentID, orgID)

--- a/consent-server/internal/consent/service.go
+++ b/consent-server/internal/consent/service.go
@@ -527,8 +527,15 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 		filters.Offset = 0
 	}
 
-	// Delegate authorization: when dataPrincipalId is set, verify caller is the principal or a delegate.
+	// ── Delegate authorization check ─────────────────────────────────────────
+	// When dataPrincipalId is set, the caller must prove they are either the
+	// principal themselves or an active delegate for that principal.
+	//
+	// Failing open (skipping this check when CallerID is empty) would allow any
+	// caller to read another person's consents simply by omitting X-User-ID.
 	if filters.DataPrincipalID != "" {
+		// Require an explicit caller identity — no anonymous access to another
+		// principal's consents.
 		if filters.CallerID == "" {
 			logger.Warn("dataPrincipalId set but caller identity is missing")
 			return nil, serviceerror.CustomServiceError(
@@ -549,7 +556,8 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 		}
 
 		if authorizedIDs == nil {
-			// Self-access — clear filter so store does not join on delegation attribute.
+			// callerID == principalID — unrestricted self-access.
+			// Clear DataPrincipalID so the store does not filter by delegation attribute.
 			filters.DataPrincipalID = ""
 		} else if len(authorizedIDs) == 0 {
 			logger.Warn("Caller not authorized for principal",
@@ -561,9 +569,11 @@ func (consentService *consentService) SearchConsentsDetailed(ctx context.Context
 					filters.CallerID, filters.DataPrincipalID),
 			)
 		} else {
+			// Pass the authorized IDs directly to the DB filters so pagination works natively
 			filters.AuthorizedConsentIDs = authorizedIDs
 		}
 	}
+	// ── end delegate authorization check ─────────────────────────────────────
 
 	// Step 1: Search consents
 	consentStore := consentService.stores.Consent
@@ -750,8 +760,15 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 			fmt.Sprintf("Client '%s' is not authorized to update consent '%s'", clientID, consentID))
 	}
 
-	// Delegation-aware modify check.
+	// ── Delegation-aware modify check ────────────────────────────────────────
+	// For self-consented records this is a no-op (IsGuardianConsent==false).
+	// For delegated consents the rules are:
+	//   if delegation expired    → only the principal (now adult) may modify
+	//   if caller == principal   → allowed, EXCEPT under active ANY-policy
 	//                              delegation where the guardian controls modifications
+	//   if caller == delegate    → the delegate row must have canModify=true AND
+	//                              onBehalfOf == principalID
+	// Note: Unlike revocation, SUBJECT_ONLY policy does NOT block delegates
 	// from modifying — it only restricts who can revoke.
 	{
 		attributes, attErr := consentStore.GetAttributesByConsentID(ctx, consentID, orgID)
@@ -839,6 +856,7 @@ func (consentService *consentService) UpdateConsent(ctx context.Context, req mod
 			}
 		}
 	}
+	// ── end delegation modify check ─────────────────────────────────────────
 
 	currentTime := utils.GetCurrentTimeMillis()
 	previousStatus := existing.CurrentStatus
@@ -1197,13 +1215,9 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 		return nil, serviceerror.CustomServiceError(ErrorConsentAlreadyRevoked, fmt.Sprintf("Consent with ID '%s' is already revoked", consentID))
 	}
 
-	// ── Delegation-aware revocation check ────────────
-	// For normal self-consented records this entire block is a no-op because
-	// parseDelegationConfig returns IsGuardianConsent()=false.
-	//
-	//   if policy = SUBJECT_ONLY    → only the principal may revoke; delegates blocked
-	//   if policy = ANY             → only delegates with canRevoke=true may revoke; principal blocked
-	//   if policy = BOTH            → both principal and delegates with canRevoke=true may revoke
+	// Delegation-aware revocation check.
+	// No-op for normal self-consented records (IsGuardianConsent=false).
+	var revokeDelegCfg model.DelegationConfig
 	{
 		attributes, attErr := store.GetAttributesByConsentID(ctx, consentID, orgID)
 		if attErr != nil {
@@ -1216,14 +1230,14 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 		for _, a := range attributes {
 			attMap[a.AttKey] = a.AttValue
 		}
-		delegCfg := parseDelegationConfig(attMap)
+		revokeDelegCfg = parseDelegationConfig(attMap)
 
-		if delegCfg.IsGuardianConsent() {
-			principalID := delegCfg.PrincipalID
+		if revokeDelegCfg.IsGuardianConsent() {
+			principalID := revokeDelegCfg.PrincipalID
 			callerID := strings.TrimSpace(req.ActionBy)
 			isPrincipal := callerID == principalID
 
-			if delegCfg.IsExpired() {
+			if revokeDelegCfg.IsExpired() {
 				// delegation ended (e.g., child is now an adult).
 				// Only the principal has authority; delegates are locked out.
 				if !isPrincipal {
@@ -1245,7 +1259,7 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 				// SUBJECT_ONLY means only the principal may revoke; delegates are blocked.
 				// ANY means only delegates with canRevoke=true may revoke; principal is blocked.
 				// BOTH means both the principal and delegates with canRevoke=true may revoke.
-				if delegCfg.RevocationPolicy == model.RevocationPolicySubjectOnly {
+				if revokeDelegCfg.RevocationPolicy == model.RevocationPolicySubjectOnly {
 					if !isPrincipal {
 						// Delegate blocked by policy.
 						logger.Warn("Revocation denied: policy is SUBJECT_ONLY",
@@ -1264,7 +1278,7 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 					// Used for capable adults — power of attorney, voluntary
 					// assisted delegation, any scenario where the data subject
 					// retains full authority alongside their delegate.
-					if delegCfg.RevocationPolicy == model.RevocationPolicyBoth {
+					if revokeDelegCfg.RevocationPolicy == model.RevocationPolicyBoth {
 						logger.Debug("BOTH policy: principal revoking their own consent",
 							log.String("principal_id", principalID))
 						// Fall through — allow revocation to continue.
@@ -1327,6 +1341,7 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 			}
 		}
 	}
+	// ── end delegation revocation check ──────────────────────────────────────────
 
 	currentTime := utils.GetCurrentTimeMillis()
 
@@ -1334,43 +1349,30 @@ func (consentService *consentService) RevokeConsent(ctx context.Context, consent
 	auditID := utils.GenerateUUID()
 	reason := req.RevocationReason
 
-	// Delegation-aware audit enrichment.
-	// When the revoker is acting as a delegate for another person, prepend a
-	// structured marker to the Reason field so the audit log answers
-	// "who revoked on whose behalf?" without a schema change. The marker is
-	// machine-parseable (delegateAction=...) and human-readable.
-	{
-		attributes, attErr := store.GetAttributesByConsentID(ctx, consentID, orgID)
-		if attErr == nil {
-			attMap := make(map[string]string)
-			for _, a := range attributes {
-				attMap[a.AttKey] = a.AttValue
-			}
-			delegCfg := parseDelegationConfig(attMap)
-			if delegCfg.IsGuardianConsent() && req.ActionBy != delegCfg.PrincipalID {
-				// Delegate is acting — record the relationship.
-				marker := fmt.Sprintf(
-					"[delegateAction=true; actor=%s; onBehalfOf=%s; delegationType=%s]",
-					req.ActionBy, delegCfg.PrincipalID, delegCfg.Type,
-				)
-				if reason == "" {
-					reason = marker
-				} else {
-					reason = marker + " " + reason
-				}
-			} else if delegCfg.IsGuardianConsent() && req.ActionBy == delegCfg.PrincipalID {
-				// Principal acting on their own consent under a delegation record
-				// (e.g., now-adult child revoking after guardian.valid_until).
-				marker := fmt.Sprintf(
-					"[principalAction=true; actor=%s; delegationExpired=%t]",
-					req.ActionBy, delegCfg.IsExpired(),
-				)
-				if reason == "" {
-					reason = marker
-				} else {
-					reason = marker + " " + reason
-				}
-			}
+	// ── Delegation-aware audit enrichment ───────────────────────────────────
+	// Delegation-aware audit enrichment (reuses revokeDelegCfg from authorization check).
+	trimmedActionBy := strings.TrimSpace(req.ActionBy)
+	if revokeDelegCfg.IsGuardianConsent() && trimmedActionBy != revokeDelegCfg.PrincipalID {
+		// Delegate is acting — record the relationship.
+		marker := fmt.Sprintf(
+			"[delegateAction=true; actor=%s; onBehalfOf=%s; delegationType=%s]",
+			trimmedActionBy, revokeDelegCfg.PrincipalID, revokeDelegCfg.Type,
+		)
+		if reason == "" {
+			reason = marker
+		} else {
+			reason = marker + " " + reason
+		}
+	} else if revokeDelegCfg.IsGuardianConsent() && trimmedActionBy == revokeDelegCfg.PrincipalID {
+		// Principal acting on their own consent under a delegation record.
+		marker := fmt.Sprintf(
+			"[principalAction=true; actor=%s; delegationExpired=%t]",
+			trimmedActionBy, revokeDelegCfg.IsExpired(),
+		)
+		if reason == "" {
+			reason = marker
+		} else {
+			reason = marker + " " + reason
 		}
 	}
 
@@ -1818,7 +1820,7 @@ func (consentService *consentService) GetConsentDelegates(ctx context.Context, c
 		}, nil
 	}
 
-	// Caller authorization check.
+	// ── Caller authorization check ───────────────────────────────────────
 	// The caller must be the data principal or an active, non-expired delegate.
 	// This prevents any authenticated user from enumerating delegate relationships
 	// by guessing consent IDs.

--- a/consent-server/internal/consent/service_test.go
+++ b/consent-server/internal/consent/service_test.go
@@ -518,12 +518,15 @@ func TestValidateDelegation_CallerIsPrincipal(t *testing.T) {
 	}
 
 	auths := []model.AuthorizationAPIRequest{
-		{Type: "delegate", Resources: map[string]interface{}{"onBehalfOf": "user-123"}},
+		{
+			Type:      "delegate",
+			UserID:    "user-123",
+			Resources: map[string]interface{}{"onBehalfOf": "user-123"},
+		},
 	}
-
 	err := validator.ValidateDelegationAttributes(attrs, auths, "user-123")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot be both the delegator and the data principal")
+	require.Contains(t, err.Error(), "cannot be the same as the data principal")
 }
 
 // valid delegation → expect no error

--- a/consent-server/internal/consent/service_test.go
+++ b/consent-server/internal/consent/service_test.go
@@ -20,11 +20,14 @@ package consent
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/wso2/openfgc/internal/consent/model"
+	"github.com/wso2/openfgc/internal/consent/validator"
 )
 
 func TestValidateConsentTypeLength(t *testing.T) {
@@ -490,4 +493,86 @@ func TestEmptyAttributesMap(t *testing.T) {
 
 	require.NotNil(t, req.Attributes)
 	require.Empty(t, req.Attributes)
+}
+
+// guardian consent missing principal_id → expect error
+func TestValidateDelegation_MissingPrincipalID(t *testing.T) {
+	attrs := map[string]string{
+		"delegation.type":            "parental_biological",
+		"guardian.valid_until":       strconv.FormatInt(time.Now().Add(24*time.Hour).Unix(), 10),
+		"guardian.revocation_policy": "ANY",
+	}
+
+	err := validator.ValidateDelegationAttributes(attrs, []model.AuthorizationAPIRequest{}, "caller-001")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "delegation.principal_id is required")
+}
+
+// caller equals principal_id → expect error
+func TestValidateDelegation_CallerIsPrincipal(t *testing.T) {
+	attrs := map[string]string{
+		"delegation.type":            "parental_biological",
+		"delegation.principal_id":    "user-123",
+		"guardian.valid_until":       strconv.FormatInt(time.Now().Add(24*time.Hour).Unix(), 10),
+		"guardian.revocation_policy": "ANY",
+	}
+
+	auths := []model.AuthorizationAPIRequest{
+		{Type: "delegate", Resources: map[string]interface{}{"onBehalfOf": "user-123"}},
+	}
+
+	err := validator.ValidateDelegationAttributes(attrs, auths, "user-123")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot be both the delegator and the data principal")
+}
+
+// valid delegation → expect no error
+func TestValidateDelegation_ValidRequest(t *testing.T) {
+	attrs := map[string]string{
+		"delegation.type":            "carer",
+		"delegation.principal_id":    "user-child",
+		"guardian.valid_until":       strconv.FormatInt(time.Now().Add(24*time.Hour).Unix(), 10),
+		"guardian.revocation_policy": "ANY",
+	}
+
+	auths := []model.AuthorizationAPIRequest{
+		{Type: "delegate", Resources: map[string]interface{}{"onBehalfOf": "user-child"}},
+	}
+
+	err := validator.ValidateDelegationAttributes(attrs, auths, "parent-001")
+	require.NoError(t, err)
+}
+
+// permanent delegation without valid_until → expect no error
+func TestValidateDelegation_PermanentDelegation(t *testing.T) {
+	attrs := map[string]string{
+		"delegation.type":            "power_of_attorney",
+		"delegation.principal_id":    "patient-001",
+		"guardian.revocation_policy": "ANY",
+	}
+
+	auths := []model.AuthorizationAPIRequest{
+		{Type: "delegate", Resources: map[string]interface{}{"onBehalfOf": "patient-001"}},
+	}
+
+	err := validator.ValidateDelegationAttributes(attrs, auths, "attorney-001")
+	require.NoError(t, err)
+}
+
+// delegation expired, delegate tries to revoke → expect error
+func TestValidateDelegation_ExpiredTimestamp(t *testing.T) {
+	attrs := map[string]string{
+		"delegation.type":            "guardian",
+		"delegation.principal_id":    "user-child",
+		"guardian.valid_until":       strconv.FormatInt(time.Now().Add(-1*time.Hour).Unix(), 10),
+		"guardian.revocation_policy": "ANY",
+	}
+
+	auths := []model.AuthorizationAPIRequest{
+		{Type: "delegate", Resources: map[string]interface{}{"onBehalfOf": "user-child"}},
+	}
+
+	err := validator.ValidateDelegationAttributes(attrs, auths, "parent-001")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be a future timestamp")
 }

--- a/consent-server/internal/consent/service_test.go
+++ b/consent-server/internal/consent/service_test.go
@@ -562,7 +562,7 @@ func TestValidateDelegation_PermanentDelegation(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// delegation expired, delegate tries to revoke → expect error
+// guardian.valid_until in the past at creation time -> expect "must be a future timestamp"
 func TestValidateDelegation_ExpiredTimestamp(t *testing.T) {
 	attrs := map[string]string{
 		"delegation.type":            "guardian",

--- a/consent-server/internal/consent/store.go
+++ b/consent-server/internal/consent/store.go
@@ -322,17 +322,20 @@ func (s *store) Search(ctx context.Context, filters model.ConsentSearchFilters) 
 		countArgs = append(countArgs, *filters.ToTime)
 	}
 
-	// Add dataPrincipalId filter (via JOIN with CONSENT_ATTRIBUTE)
+	// Add dataPrincipalId filter via INNER JOIN on CONSENT_ATTRIBUTE.
+	// The ATT_KEY predicate is pushed into the JOIN ON clause (not WHERE) so the
+	// join is narrowed before the WHERE filter runs, which reduces the number of
+	// rows the database needs to evaluate for both the count and select queries.
+	// model.AttrDelegationPrincipalID is used instead of a hardcoded literal so
+	// any future rename of the constant is automatically reflected here.
 	if filters.DataPrincipalID != "" {
 		joinClause += " INNER JOIN CONSENT_ATTRIBUTE ca_dp" +
 			" ON CONSENT.CONSENT_ID = ca_dp.CONSENT_ID" +
-			" AND CONSENT.ORG_ID = ca_dp.ORG_ID"
-		whereConditions = append(whereConditions,
-			"ca_dp.ATT_KEY = 'delegation.principal_id'")
-		whereConditions = append(whereConditions,
-			"ca_dp.ATT_VALUE = ?")
-		args = append(args, filters.DataPrincipalID)
-		countArgs = append(countArgs, filters.DataPrincipalID)
+			" AND CONSENT.ORG_ID = ca_dp.ORG_ID" +
+			" AND ca_dp.ATT_KEY = ?"
+		whereConditions = append(whereConditions, "ca_dp.ATT_VALUE = ?")
+		args = append(args, model.AttrDelegationPrincipalID, filters.DataPrincipalID)
+		countArgs = append(countArgs, model.AttrDelegationPrincipalID, filters.DataPrincipalID)
 	}
 
 	whereClause := strings.Join(whereConditions, " AND ")

--- a/consent-server/internal/consent/store.go
+++ b/consent-server/internal/consent/store.go
@@ -321,21 +321,24 @@ func (s *store) Search(ctx context.Context, filters model.ConsentSearchFilters) 
 		args = append(args, *filters.ToTime)
 		countArgs = append(countArgs, *filters.ToTime)
 	}
+	// Filter by dataPrincipalId via INNER JOIN on CONSENT_ATTRIBUTE.
+	// The attribute key predicate is pushed into the JOIN ON clause to optimize
+	// query performance by narrowing the join before the WHERE filter runs.
+	//
+	// CRITICAL: joinArgs must be prepended (not appended) to the final argument
+	// list. Since the JOIN clause appears before the WHERE clause in the SQL,
+	// its placeholder must be position #1 to prevent parameter shifting.
 
-	// Add dataPrincipalId filter via INNER JOIN on CONSENT_ATTRIBUTE.
-	// The ATT_KEY predicate is pushed into the JOIN ON clause (not WHERE) so the
-	// join is narrowed before the WHERE filter runs, which reduces the number of
-	// rows the database needs to evaluate for both the count and select queries.
-	// model.AttrDelegationPrincipalID is used instead of a hardcoded literal so
-	// any future rename of the constant is automatically reflected here.
+	joinArgs := make([]interface{}, 0, 1)
 	if filters.DataPrincipalID != "" {
 		joinClause += " INNER JOIN CONSENT_ATTRIBUTE ca_dp" +
 			" ON CONSENT.CONSENT_ID = ca_dp.CONSENT_ID" +
 			" AND CONSENT.ORG_ID = ca_dp.ORG_ID" +
 			" AND ca_dp.ATT_KEY = ?"
 		whereConditions = append(whereConditions, "ca_dp.ATT_VALUE = ?")
-		args = append(args, model.AttrDelegationPrincipalID, filters.DataPrincipalID)
-		countArgs = append(countArgs, model.AttrDelegationPrincipalID, filters.DataPrincipalID)
+		joinArgs = append(joinArgs, model.AttrDelegationPrincipalID)
+		args = append(args, filters.DataPrincipalID)
+		countArgs = append(countArgs, filters.DataPrincipalID)
 	}
 
 	whereClause := strings.Join(whereConditions, " AND ")
@@ -344,12 +347,14 @@ func (s *store) Search(ctx context.Context, filters model.ConsentSearchFilters) 
 	countQuery := fmt.Sprintf("SELECT COUNT(DISTINCT CONSENT.CONSENT_ID) as count FROM CONSENT%s WHERE %s",
 		joinClause, whereClause)
 
-	// Execute count query
+	// Execute count query.
+	// joinArgs must come first: their placeholder(s) appear in the JOIN ON clause
+	// which is rendered before the WHERE clause in the SQL string.
 	countRows, err := dbClient.Query(dbmodel.DBQuery{
 		ID:            "COUNT_SEARCH_RESULTS",
 		Query:         countQuery,
 		PostgresQuery: dbutils.ConvertToPostgresParams(countQuery),
-	}, countArgs...)
+	}, append(joinArgs, countArgs...)...)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -376,12 +381,13 @@ func (s *store) Search(ctx context.Context, filters model.ConsentSearchFilters) 
 	// Add pagination parameters
 	args = append(args, filters.Limit, filters.Offset)
 
-	// Execute search query
+	// Execute search query.
+	// joinArgs must come first for the same reason as the count query above.
 	rows, err := dbClient.Query(dbmodel.DBQuery{
 		ID:            "SEARCH_CONSENTS",
 		Query:         selectQuery,
 		PostgresQuery: dbutils.ConvertToPostgresParams(selectQuery),
-	}, args...)
+	}, append(joinArgs, args...)...)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/consent-server/internal/consent/store.go
+++ b/consent-server/internal/consent/store.go
@@ -255,7 +255,7 @@ func (s *store) Search(ctx context.Context, filters model.ConsentSearchFilters) 
 	args := []interface{}{filters.OrgID}
 	countArgs := []interface{}{filters.OrgID}
 
-	// Add AuthorizedConsentIDs filter (IN clause)
+	// Add AuthorizedConsentIDs filter (IN clause) - OPTION 1 PAGINATION FIX
 	if len(filters.AuthorizedConsentIDs) > 0 {
 		placeholders := make([]string, len(filters.AuthorizedConsentIDs))
 		for i, id := range filters.AuthorizedConsentIDs {

--- a/consent-server/internal/consent/store.go
+++ b/consent-server/internal/consent/store.go
@@ -76,6 +76,12 @@ var (
 		PostgresQuery: "DELETE FROM CONSENT_ATTRIBUTE WHERE CONSENT_ID = $1 AND ORG_ID = $2",
 	}
 
+	QueryDeleteAttributeByKey = dbmodel.DBQuery{
+		ID:            "DELETE_ATTRIBUTE_BY_KEY",
+		Query:         "DELETE FROM CONSENT_ATTRIBUTE WHERE CONSENT_ID = ? AND ATT_KEY = ? AND ORG_ID = ?",
+		PostgresQuery: "DELETE FROM CONSENT_ATTRIBUTE WHERE CONSENT_ID = $1 AND ATT_KEY = $2 AND ORG_ID = $3",
+	}
+
 	QueryFindConsentIDsByAttributeKey = dbmodel.DBQuery{
 		ID:            "FIND_CONSENT_IDS_BY_ATTRIBUTE_KEY",
 		Query:         "SELECT DISTINCT CONSENT_ID FROM CONSENT_ATTRIBUTE WHERE ATT_KEY = ? AND ORG_ID = ? ORDER BY CONSENT_ID",
@@ -249,7 +255,7 @@ func (s *store) Search(ctx context.Context, filters model.ConsentSearchFilters) 
 	args := []interface{}{filters.OrgID}
 	countArgs := []interface{}{filters.OrgID}
 
-	// Add AuthorizedConsentIDs filter (IN clause) - OPTION 1 PAGINATION FIX
+	// Add AuthorizedConsentIDs filter (IN clause)
 	if len(filters.AuthorizedConsentIDs) > 0 {
 		placeholders := make([]string, len(filters.AuthorizedConsentIDs))
 		for i, id := range filters.AuthorizedConsentIDs {
@@ -532,6 +538,14 @@ func (s *store) GetAttributesByConsentIDs(ctx context.Context, consentIDs []stri
 // DeleteAttributesByConsentID deletes all attributes for a consent within a transaction
 func (s *store) DeleteAttributesByConsentID(tx dbmodel.TxInterface, consentID, orgID string) error {
 	_, err := tx.Exec(QueryDeleteAttributesByConsentID, consentID, orgID)
+	return err
+}
+
+// DeleteAttributeByKey deletes a single attribute by key from a consent.
+// Used by the convert-to-self-consent flow to strip delegation metadata
+// while preserving all other attributes.
+func (s *store) DeleteAttributeByKey(tx dbmodel.TxInterface, consentID, attKey, orgID string) error {
+	_, err := tx.Exec(QueryDeleteAttributeByKey, consentID, attKey, orgID)
 	return err
 }
 

--- a/consent-server/internal/consent/store.go
+++ b/consent-server/internal/consent/store.go
@@ -256,14 +256,19 @@ func (s *store) Search(ctx context.Context, filters model.ConsentSearchFilters) 
 	countArgs := []interface{}{filters.OrgID}
 
 	// Add AuthorizedConsentIDs filter (IN clause) - OPTION 1 PAGINATION FIX
-	if len(filters.AuthorizedConsentIDs) > 0 {
-		placeholders := make([]string, len(filters.AuthorizedConsentIDs))
-		for i, id := range filters.AuthorizedConsentIDs {
-			placeholders[i] = "?"
-			args = append(args, id)
-			countArgs = append(countArgs, id)
+	if filters.AuthorizedConsentIDs != nil {
+		if len(filters.AuthorizedConsentIDs) == 0 {
+			// Non-nil but empty means "caller is authorized for zero consents" — return nothing.
+			whereConditions = append(whereConditions, "1 = 0")
+		} else {
+			placeholders := make([]string, len(filters.AuthorizedConsentIDs))
+			for i, id := range filters.AuthorizedConsentIDs {
+				placeholders[i] = "?"
+				args = append(args, id)
+				countArgs = append(countArgs, id)
+			}
+			whereConditions = append(whereConditions, fmt.Sprintf("CONSENT.CONSENT_ID IN (%s)", strings.Join(placeholders, ",")))
 		}
-		whereConditions = append(whereConditions, fmt.Sprintf("CONSENT.CONSENT_ID IN (%s)", strings.Join(placeholders, ",")))
 	}
 
 	// Add consentTypes filter (IN clause)

--- a/consent-server/internal/consent/store.go
+++ b/consent-server/internal/consent/store.go
@@ -249,6 +249,17 @@ func (s *store) Search(ctx context.Context, filters model.ConsentSearchFilters) 
 	args := []interface{}{filters.OrgID}
 	countArgs := []interface{}{filters.OrgID}
 
+	// Add AuthorizedConsentIDs filter (IN clause) - OPTION 1 PAGINATION FIX
+	if len(filters.AuthorizedConsentIDs) > 0 {
+		placeholders := make([]string, len(filters.AuthorizedConsentIDs))
+		for i, id := range filters.AuthorizedConsentIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+			countArgs = append(countArgs, id)
+		}
+		whereConditions = append(whereConditions, fmt.Sprintf("CONSENT.CONSENT_ID IN (%s)", strings.Join(placeholders, ",")))
+	}
+
 	// Add consentTypes filter (IN clause)
 	if len(filters.ConsentTypes) > 0 {
 		placeholders := make([]string, len(filters.ConsentTypes))
@@ -321,6 +332,7 @@ func (s *store) Search(ctx context.Context, filters model.ConsentSearchFilters) 
 		args = append(args, *filters.ToTime)
 		countArgs = append(countArgs, *filters.ToTime)
 	}
+
 	// Filter by dataPrincipalId via INNER JOIN on CONSENT_ATTRIBUTE.
 	// The attribute key predicate is pushed into the JOIN ON clause to optimize
 	// query performance by narrowing the join before the WHERE filter runs.

--- a/consent-server/internal/consent/store.go
+++ b/consent-server/internal/consent/store.go
@@ -76,12 +76,6 @@ var (
 		PostgresQuery: "DELETE FROM CONSENT_ATTRIBUTE WHERE CONSENT_ID = $1 AND ORG_ID = $2",
 	}
 
-	QueryDeleteAttributeByKey = dbmodel.DBQuery{
-		ID:            "DELETE_ATTRIBUTE_BY_KEY",
-		Query:         "DELETE FROM CONSENT_ATTRIBUTE WHERE CONSENT_ID = ? AND ATT_KEY = ? AND ORG_ID = ?",
-		PostgresQuery: "DELETE FROM CONSENT_ATTRIBUTE WHERE CONSENT_ID = $1 AND ATT_KEY = $2 AND ORG_ID = $3",
-	}
-
 	QueryFindConsentIDsByAttributeKey = dbmodel.DBQuery{
 		ID:            "FIND_CONSENT_IDS_BY_ATTRIBUTE_KEY",
 		Query:         "SELECT DISTINCT CONSENT_ID FROM CONSENT_ATTRIBUTE WHERE ATT_KEY = ? AND ORG_ID = ? ORDER BY CONSENT_ID",
@@ -543,14 +537,6 @@ func (s *store) GetAttributesByConsentIDs(ctx context.Context, consentIDs []stri
 // DeleteAttributesByConsentID deletes all attributes for a consent within a transaction
 func (s *store) DeleteAttributesByConsentID(tx dbmodel.TxInterface, consentID, orgID string) error {
 	_, err := tx.Exec(QueryDeleteAttributesByConsentID, consentID, orgID)
-	return err
-}
-
-// DeleteAttributeByKey deletes a single attribute by key from a consent.
-// Used by the convert-to-self-consent flow to strip delegation metadata
-// while preserving all other attributes.
-func (s *store) DeleteAttributeByKey(tx dbmodel.TxInterface, consentID, attKey, orgID string) error {
-	_, err := tx.Exec(QueryDeleteAttributeByKey, consentID, attKey, orgID)
 	return err
 }
 

--- a/consent-server/internal/consent/store.go
+++ b/consent-server/internal/consent/store.go
@@ -110,25 +110,25 @@ var (
 	QueryGetConsentPurposesByConsentID = dbmodel.DBQuery{
 		ID: "GET_PURPOSES_BY_CONSENT_ID",
 		Query: `
-			SELECT 
-				pgc.CONSENT_ID,
-				pgc.PURPOSE_ID,
-				pg.NAME as PURPOSE_NAME
-			FROM PURPOSE_CONSENT_MAPPING pgc
-			JOIN CONSENT_PURPOSE pg ON pgc.PURPOSE_ID = pg.ID AND pgc.ORG_ID = pg.ORG_ID
-			WHERE pgc.CONSENT_ID = ? AND pgc.ORG_ID = ?
-			ORDER BY pg.NAME
-		`,
+            SELECT 
+                pgc.CONSENT_ID,
+                pgc.PURPOSE_ID,
+                pg.NAME as PURPOSE_NAME
+            FROM PURPOSE_CONSENT_MAPPING pgc
+            JOIN CONSENT_PURPOSE pg ON pgc.PURPOSE_ID = pg.ID AND pgc.ORG_ID = pg.ORG_ID
+            WHERE pgc.CONSENT_ID = ? AND pgc.ORG_ID = ?
+            ORDER BY pg.NAME
+        `,
 		PostgresQuery: `
-			SELECT 
-				pgc.CONSENT_ID,
-				pgc.PURPOSE_ID,
-				pg.NAME as PURPOSE_NAME
-			FROM PURPOSE_CONSENT_MAPPING pgc
-			JOIN CONSENT_PURPOSE pg ON pgc.PURPOSE_ID = pg.ID AND pgc.ORG_ID = pg.ORG_ID
-			WHERE pgc.CONSENT_ID = $1 AND pgc.ORG_ID = $2
-			ORDER BY pg.NAME
-		`,
+            SELECT 
+                pgc.CONSENT_ID,
+                pgc.PURPOSE_ID,
+                pg.NAME as PURPOSE_NAME
+            FROM PURPOSE_CONSENT_MAPPING pgc
+            JOIN CONSENT_PURPOSE pg ON pgc.PURPOSE_ID = pg.ID AND pgc.ORG_ID = pg.ORG_ID
+            WHERE pgc.CONSENT_ID = $1 AND pgc.ORG_ID = $2
+            ORDER BY pg.NAME
+        `,
 	}
 
 	QueryCheckPurposeUsedInConsents = dbmodel.DBQuery{
@@ -146,41 +146,41 @@ var (
 	QueryGetElementApprovalsByConsentID = dbmodel.DBQuery{
 		ID: "GET_ELEMENT_APPROVALS_BY_CONSENT_ID",
 		Query: `
-			SELECT 
-				pa.CONSENT_ID,
-				pa.PURPOSE_ID,
-				pg.NAME as PURPOSE_NAME,
-				pa.ELEMENT_ID,
-				p.NAME as ELEMENT_NAME,
-				pa.IS_USER_APPROVED,
-				pa.VALUE,
-				gm.IS_MANDATORY
-			FROM CONSENT_ELEMENT_APPROVAL pa
-		JOIN CONSENT_ELEMENT p ON pa.ELEMENT_ID = p.ID AND pa.ORG_ID = p.ORG_ID
-		JOIN CONSENT_PURPOSE pg ON pa.PURPOSE_ID = pg.ID AND pa.ORG_ID = pg.ORG_ID
-		JOIN PURPOSE_ELEMENT_MAPPING gm ON pa.PURPOSE_ID = gm.PURPOSE_ID 
-			AND pa.ELEMENT_ID = gm.ELEMENT_ID AND pa.ORG_ID = gm.ORG_ID
-			WHERE pa.CONSENT_ID = ? AND pa.ORG_ID = ?
-			ORDER BY pg.NAME, p.NAME
-		`,
+            SELECT 
+                pa.CONSENT_ID,
+                pa.PURPOSE_ID,
+                pg.NAME as PURPOSE_NAME,
+                pa.ELEMENT_ID,
+                p.NAME as ELEMENT_NAME,
+                pa.IS_USER_APPROVED,
+                pa.VALUE,
+                gm.IS_MANDATORY
+            FROM CONSENT_ELEMENT_APPROVAL pa
+        JOIN CONSENT_ELEMENT p ON pa.ELEMENT_ID = p.ID AND pa.ORG_ID = p.ORG_ID
+        JOIN CONSENT_PURPOSE pg ON pa.PURPOSE_ID = pg.ID AND pa.ORG_ID = pg.ORG_ID
+        JOIN PURPOSE_ELEMENT_MAPPING gm ON pa.PURPOSE_ID = gm.PURPOSE_ID 
+            AND pa.ELEMENT_ID = gm.ELEMENT_ID AND pa.ORG_ID = gm.ORG_ID
+            WHERE pa.CONSENT_ID = ? AND pa.ORG_ID = ?
+            ORDER BY pg.NAME, p.NAME
+        `,
 		PostgresQuery: `
-			SELECT 
-				pa.CONSENT_ID,
-				pa.PURPOSE_ID,
-				pg.NAME as PURPOSE_NAME,
-				pa.ELEMENT_ID,
-				p.NAME as ELEMENT_NAME,
-				pa.IS_USER_APPROVED,
-				pa.VALUE,
-				gm.IS_MANDATORY
-			FROM CONSENT_ELEMENT_APPROVAL pa
-		JOIN CONSENT_ELEMENT p ON pa.ELEMENT_ID = p.ID AND pa.ORG_ID = p.ORG_ID
-		JOIN CONSENT_PURPOSE pg ON pa.PURPOSE_ID = pg.ID AND pa.ORG_ID = pg.ORG_ID
-		JOIN PURPOSE_ELEMENT_MAPPING gm ON pa.PURPOSE_ID = gm.PURPOSE_ID 
-			AND pa.ELEMENT_ID = gm.ELEMENT_ID AND pa.ORG_ID = gm.ORG_ID
-			WHERE pa.CONSENT_ID = $1 AND pa.ORG_ID = $2
-			ORDER BY pg.NAME, p.NAME
-		`,
+            SELECT 
+                pa.CONSENT_ID,
+                pa.PURPOSE_ID,
+                pg.NAME as PURPOSE_NAME,
+                pa.ELEMENT_ID,
+                p.NAME as ELEMENT_NAME,
+                pa.IS_USER_APPROVED,
+                pa.VALUE,
+                gm.IS_MANDATORY
+            FROM CONSENT_ELEMENT_APPROVAL pa
+        JOIN CONSENT_ELEMENT p ON pa.ELEMENT_ID = p.ID AND pa.ORG_ID = p.ORG_ID
+        JOIN CONSENT_PURPOSE pg ON pa.PURPOSE_ID = pg.ID AND pa.ORG_ID = pg.ORG_ID
+        JOIN PURPOSE_ELEMENT_MAPPING gm ON pa.PURPOSE_ID = gm.PURPOSE_ID 
+            AND pa.ELEMENT_ID = gm.ELEMENT_ID AND pa.ORG_ID = gm.ORG_ID
+            WHERE pa.CONSENT_ID = $1 AND pa.ORG_ID = $2
+            ORDER BY pg.NAME, p.NAME
+        `,
 	}
 
 	QueryDeleteConsentPurposesByConsentID = dbmodel.DBQuery{
@@ -320,6 +320,19 @@ func (s *store) Search(ctx context.Context, filters model.ConsentSearchFilters) 
 		whereConditions = append(whereConditions, "CONSENT.UPDATED_TIME <= ?")
 		args = append(args, *filters.ToTime)
 		countArgs = append(countArgs, *filters.ToTime)
+	}
+
+	// Add dataPrincipalId filter (via JOIN with CONSENT_ATTRIBUTE)
+	if filters.DataPrincipalID != "" {
+		joinClause += " INNER JOIN CONSENT_ATTRIBUTE ca_dp" +
+			" ON CONSENT.CONSENT_ID = ca_dp.CONSENT_ID" +
+			" AND CONSENT.ORG_ID = ca_dp.ORG_ID"
+		whereConditions = append(whereConditions,
+			"ca_dp.ATT_KEY = 'delegation.principal_id'")
+		whereConditions = append(whereConditions,
+			"ca_dp.ATT_VALUE = ?")
+		args = append(args, filters.DataPrincipalID)
+		countArgs = append(countArgs, filters.DataPrincipalID)
 	}
 
 	whereClause := strings.Join(whereConditions, " AND ")

--- a/consent-server/internal/consent/validator/consent.go
+++ b/consent-server/internal/consent/validator/consent.go
@@ -258,9 +258,17 @@ func ValidateDelegationAttributes(
 			"delegation.principal_id is required when delegation.type is set")
 	}
 
+	// Without it we cannot enforce the self-delegation check below, so we must
+	// reject the request rather than silently skip the guard.
+	callerID = strings.TrimSpace(callerID)
+	if callerID == "" {
+		return fmt.Errorf(
+			"caller identity (X-User-ID) is required when delegation.type is set")
+	}
+
 	// The person giving consent must not be the same as the data subject.
 	// Applies to all delegation types: parental, carer, power-of-attorney, etc.
-	if callerID != "" && callerID == principalID {
+	if callerID == principalID {
 		return fmt.Errorf(
 			"caller '%s' cannot be both the delegator and the data principal", callerID)
 	}
@@ -275,6 +283,15 @@ func ValidateDelegationAttributes(
 		if err != nil || validUntil <= 0 {
 			return fmt.Errorf(
 				"guardian.valid_until must be a valid positive Unix timestamp in seconds")
+		}
+
+		// Unix seconds will not exceed 1e11 until the year 5138, so any value
+		// larger than that is almost certainly a millisecond value by mistake,
+		// which would create a delegation ~1000x longer than intended.
+		const maxUnixSeconds = int64(100_000_000_000)
+		if validUntil > maxUnixSeconds {
+			return fmt.Errorf(
+				"guardian.valid_until appears to be in milliseconds; provide a Unix timestamp in seconds")
 		}
 		if time.Now().Unix() >= validUntil {
 			return fmt.Errorf(

--- a/consent-server/internal/consent/validator/consent.go
+++ b/consent-server/internal/consent/validator/consent.go
@@ -82,7 +82,7 @@ func ValidateConsentUpdateRequest(req model.ConsentAPIUpdateRequest) error {
 	if req.Type == "" && req.Frequency == nil &&
 		req.ValidityTime == nil && req.RecurringIndicator == nil &&
 		req.Attributes == nil && req.Authorizations == nil && req.Purposes == nil &&
-		req.DataAccessValidityDuration == nil {
+		req.DataAccessValidityDuration == nil && !req.ConvertToSelfConsent {
 		return fmt.Errorf("at least one field must be provided for update")
 	}
 
@@ -99,6 +99,30 @@ func ValidateConsentUpdateRequest(req model.ConsentAPIUpdateRequest) error {
 	// Validate frequency if provided
 	if req.Frequency != nil && *req.Frequency < 0 {
 		return fmt.Errorf("frequency must be non-negative")
+	}
+
+	// Delegation attributes are immutable after consent creation.
+	// Blocking overwrite prevents a caller from extending guardian.valid_until
+	// indefinitely or changing the revocation policy after the fact.
+	// Exception: convertToSelfConsent bypasses this guard because the attrs
+	// are being DELETED entirely (not modified). The service layer validates
+	// that the caller is the principal and the delegation has expired.
+	if !req.ConvertToSelfConsent {
+		protectedKeys := []string{
+			model.AttrDelegationType,
+			model.AttrDelegationPrincipalID,
+			model.AttrGuardianValidUntil,
+			model.AttrGuardianRevocationPolicy,
+		}
+		if req.Attributes != nil {
+			for _, key := range protectedKeys {
+				if _, exists := req.Attributes[key]; exists {
+					return fmt.Errorf(
+						"delegation attribute '%s' is immutable after consent creation "+
+							"and cannot be modified via update", key)
+				}
+			}
+		}
 	}
 
 	// Validate auth resources if provided
@@ -211,7 +235,7 @@ func IsConsentExpired(validityTime int64) bool {
 
 	// Detect if timestamp is in seconds or milliseconds
 	// A reasonable cutoff: timestamps > 10^11 are likely in milliseconds
-	// This works until year 5138 in seconds (safely covers our use case)
+	// This works until year 5138 in seconds
 	const timestampCutoff = 100000000000 // 10^11
 
 	var validityTimeMillis int64
@@ -287,6 +311,18 @@ func ValidateDelegationAttributes(
 	// If the caller IS the principal, at least one real delegate with a different
 	// userId must be registered — otherwise there is no actual delegation happening.
 	if callerID == principalID {
+		// Guard against a minor self-initiating parental consent.
+		// Parental delegation must be initiated by the parent, not the child, per
+		// DPDP Section 9 and the stated design requirement.
+		// Non-parental delegation types (guardian, carer, power_of_attorney) are still
+		// allowed because a capable adult may legitimately initiate those over their own data.
+		if delegationType == "parental_biological" || delegationType == "parental_legal" {
+			return fmt.Errorf(
+				"parental delegation must be initiated by the parent, not the data principal; "+
+					"caller '%s' cannot be the principal for delegation.type '%s'",
+				callerID, delegationType)
+		}
+
 		hasRealDelegate := false
 		for _, auth := range authorizations {
 			delegateUserID := strings.TrimSpace(auth.UserID)
@@ -367,13 +403,11 @@ func ValidateDelegationAttributes(
 	// trying to validate one principal and persist another.
 	found := false
 	for _, auth := range authorizations {
-		// Resolve the effective principal from the Delegation struct (new path).
 		effectivePrincipal := ""
 		if auth.Delegation != nil {
 			effectivePrincipal = strings.TrimSpace(auth.Delegation.PrincipalID)
 		}
 
-		// Resolve from Resources map (legacy path).
 		if resources, ok := auth.Resources.(map[string]interface{}); ok {
 			if onBehalfOf, _ := resources["onBehalfOf"].(string); onBehalfOf != "" {
 				// If Delegation was also set, the two values must agree.

--- a/consent-server/internal/consent/validator/consent.go
+++ b/consent-server/internal/consent/validator/consent.go
@@ -235,7 +235,7 @@ func IsConsentExpired(validityTime int64) bool {
 
 	// Detect if timestamp is in seconds or milliseconds
 	// A reasonable cutoff: timestamps > 10^11 are likely in milliseconds
-	// This works until year 5138 in seconds
+	// This works until year 5138 in seconds (safely covers our use case)
 	const timestampCutoff = 100000000000 // 10^11
 
 	var validityTimeMillis int64
@@ -275,8 +275,8 @@ func ValidateDelegationAttributes(
 	callerID string,
 ) error {
 	// Not a delegated consent — skip all delegation checks.
-	delegationType := attributes[model.AttrDelegationType]
-	if strings.TrimSpace(delegationType) == "" {
+	delegationType := strings.TrimSpace(attributes[model.AttrDelegationType])
+	if delegationType == "" {
 		return nil
 	}
 
@@ -316,7 +316,7 @@ func ValidateDelegationAttributes(
 		// DPDP Section 9 and the stated design requirement.
 		// Non-parental delegation types (guardian, carer, power_of_attorney) are still
 		// allowed because a capable adult may legitimately initiate those over their own data.
-		if delegationType == "parental_biological" || delegationType == "parental_legal" {
+		if delegationType == "parental" || delegationType == "parental_biological" || delegationType == "parental_legal" {
 			return fmt.Errorf(
 				"parental delegation must be initiated by the parent, not the data principal; "+
 					"caller '%s' cannot be the principal for delegation.type '%s'",
@@ -408,6 +408,7 @@ func ValidateDelegationAttributes(
 			effectivePrincipal = strings.TrimSpace(auth.Delegation.PrincipalID)
 		}
 
+		// Resolve from Resources map (legacy path).
 		if resources, ok := auth.Resources.(map[string]interface{}); ok {
 			if onBehalfOf, _ := resources["onBehalfOf"].(string); onBehalfOf != "" {
 				// If Delegation was also set, the two values must agree.

--- a/consent-server/internal/consent/validator/consent.go
+++ b/consent-server/internal/consent/validator/consent.go
@@ -203,7 +203,7 @@ func EvaluateConsentStatusFromAuthStatuses(authStatuses []string) string {
 	}
 }
 
-// IsExpired checks if a given validity time has expired
+// IsConsentExpired checks if a given validity time has expired
 func IsConsentExpired(validityTime int64) bool {
 	if validityTime == 0 {
 		return false // No expiry set
@@ -235,7 +235,9 @@ func IsConsentExpired(validityTime int64) bool {
 //
 // Rules enforced:
 //  1. delegation.principal_id must be provided
-//  2. The caller (X-User-ID) must NOT equal the principal_id — cannot self-delegate
+//  2. No delegate (auth.UserID) may equal the principal_id — that is circular.
+//     The caller may legitimately be the principal when proactively setting up
+//     delegation over their own data (e.g. capable adult initiating power of attorney).
 //  3. guardian.valid_until — OPTIONAL. When provided it must be a future Unix timestamp
 //     in seconds. Millisecond values are rejected to avoid delegations ~1000x longer
 //     than intended. Omit for permanent delegations (power of attorney, permanent
@@ -268,11 +270,37 @@ func ValidateDelegationAttributes(
 			"caller identity (X-User-ID) is required when delegation.type is set")
 	}
 
-	// The person giving consent must not be the same as the data subject.
-	// Applies to all delegation types: parental, carer, power-of-attorney, etc.
+	// The delegate being granted authority must not be the same as the data principal.
+	// That would be circular — a person cannot be delegated authority over their own consent.
+	// The caller MAY be the principal: a capable adult proactively setting up power of
+	// attorney for someone else over their own data is a valid real-world scenario.
+	for _, auth := range authorizations {
+		delegateUserID := strings.TrimSpace(auth.UserID)
+		if delegateUserID != "" && delegateUserID == principalID {
+			return fmt.Errorf(
+				"delegate userId '%s' cannot be the same as the data principal; "+
+					"a person cannot be delegated authority over their own consent",
+				delegateUserID)
+		}
+	}
+
+	// If the caller IS the principal, at least one real delegate with a different
+	// userId must be registered — otherwise there is no actual delegation happening.
 	if callerID == principalID {
-		return fmt.Errorf(
-			"caller '%s' cannot be both the delegator and the data principal", callerID)
+		hasRealDelegate := false
+		for _, auth := range authorizations {
+			delegateUserID := strings.TrimSpace(auth.UserID)
+			if delegateUserID != "" && delegateUserID != principalID {
+				hasRealDelegate = true
+				break
+			}
+		}
+		if !hasRealDelegate {
+			return fmt.Errorf(
+				"when caller is the data principal, at least one authorization must "+
+					"register a delegate with a different userId for principal '%s'",
+				principalID)
+		}
 	}
 
 	// guardian.valid_until is OPTIONAL — permanent delegations (e.g., power of attorney
@@ -308,19 +336,23 @@ func ValidateDelegationAttributes(
 	if policy == "" {
 		return fmt.Errorf(
 			"guardian.revocation_policy is required for delegated consents; "+
-				"valid values: %s, %s",
+				"valid values: %s, %s or %s",
 			model.RevocationPolicyAny,
 			model.RevocationPolicySubjectOnly,
+			model.RevocationPolicyBoth,
 		)
 	}
 	switch model.RevocationPolicy(policy) {
-	case model.RevocationPolicyAny, model.RevocationPolicySubjectOnly:
+	case model.RevocationPolicyAny,
+		model.RevocationPolicySubjectOnly,
+		model.RevocationPolicyBoth:
 
 	default:
 		return fmt.Errorf(
-			"guardian.revocation_policy must be %s or %s, got: %s",
+			"guardian.revocation_policy must be %s, %s or %s, got: %s",
 			model.RevocationPolicyAny,
 			model.RevocationPolicySubjectOnly,
+			model.RevocationPolicyBoth,
 			policy,
 		)
 	}

--- a/consent-server/internal/consent/validator/consent.go
+++ b/consent-server/internal/consent/validator/consent.go
@@ -86,6 +86,18 @@ func ValidateConsentUpdateRequest(req model.ConsentAPIUpdateRequest) error {
 		return fmt.Errorf("at least one field must be provided for update")
 	}
 
+	// convertToSelfConsent is an exclusive operation — it cannot be combined
+	// with other consent field updates. The conversion only deletes delegation
+	// metadata; any other changes must be made in a separate update call.
+	if req.ConvertToSelfConsent &&
+		(req.Type != "" || req.Frequency != nil ||
+			req.ValidityTime != nil || req.RecurringIndicator != nil ||
+			req.Attributes != nil || req.Authorizations != nil || req.Purposes != nil ||
+			req.DataAccessValidityDuration != nil) {
+		return fmt.Errorf("convertToSelfConsent cannot be combined with other consent updates; " +
+			"perform the conversion first, then update other fields separately")
+	}
+
 	// Validate Type length if provided (match create constraint)
 	if req.Type != "" && len(req.Type) > 64 {
 		return fmt.Errorf("type must be at most 64 characters")
@@ -279,6 +291,9 @@ func ValidateDelegationAttributes(
 	if delegationType == "" {
 		return nil
 	}
+	// Lowercase copy for case-insensitive comparisons; the original
+	// delegationType is preserved for storage and error messages.
+	delegationTypeLower := strings.ToLower(delegationType)
 
 	principalID := strings.TrimSpace(attributes[model.AttrDelegationPrincipalID])
 	if principalID == "" {
@@ -316,7 +331,7 @@ func ValidateDelegationAttributes(
 		// DPDP Section 9 and the stated design requirement.
 		// Non-parental delegation types (guardian, carer, power_of_attorney) are still
 		// allowed because a capable adult may legitimately initiate those over their own data.
-		if delegationType == "parental" || delegationType == "parental_biological" || delegationType == "parental_legal" {
+		if delegationTypeLower == "parental" || delegationTypeLower == "parental_biological" || delegationTypeLower == "parental_legal" {
 			return fmt.Errorf(
 				"parental delegation must be initiated by the parent, not the data principal; "+
 					"caller '%s' cannot be the principal for delegation.type '%s'",
@@ -403,6 +418,7 @@ func ValidateDelegationAttributes(
 	// trying to validate one principal and persist another.
 	found := false
 	for _, auth := range authorizations {
+		// Resolve the effective principal from the Delegation struct (new path).
 		effectivePrincipal := ""
 		if auth.Delegation != nil {
 			effectivePrincipal = strings.TrimSpace(auth.Delegation.PrincipalID)

--- a/consent-server/internal/consent/validator/consent.go
+++ b/consent-server/internal/consent/validator/consent.go
@@ -241,7 +241,8 @@ func IsConsentExpired(validityTime int64) bool {
 //     than intended. Omit for permanent delegations (power of attorney, permanent
 //     disability carer, etc.) where there is no natural expiry date.
 //  4. guardian.revocation_policy must be set to a valid value
-//  5. At least one authorization must have onBehalfOf = principal_id
+//  5. At least one authorization must have onBehalfOf = principal_id, sourced from
+//     either auth.Resources["onBehalfOf"] or auth.Delegation.PrincipalID
 func ValidateDelegationAttributes(
 	attributes map[string]string,
 	authorizations []model.AuthorizationAPIRequest,
@@ -325,18 +326,45 @@ func ValidateDelegationAttributes(
 	}
 
 	// At least one authorization must register a delegate for the principal.
+	//
+	// The principal can be identified via two paths:
+	//   1. auth.Resources["onBehalfOf"]  — legacy / direct JSON field
+	//   2. auth.Delegation.PrincipalID   — new typed delegation struct
+	//
+	// When both are present they must agree; a mismatch means the caller is
+	// trying to validate one principal and persist another.
 	found := false
 	for _, auth := range authorizations {
+		// Resolve the effective principal from the Delegation struct (new path).
+		effectivePrincipal := ""
+		if auth.Delegation != nil {
+			effectivePrincipal = strings.TrimSpace(auth.Delegation.PrincipalID)
+		}
+
+		// Resolve from Resources map (legacy path).
 		if resources, ok := auth.Resources.(map[string]interface{}); ok {
-			if onBehalfOf, _ := resources["onBehalfOf"].(string); onBehalfOf == principalID {
-				found = true
-				break
+			if onBehalfOf, _ := resources["onBehalfOf"].(string); onBehalfOf != "" {
+				// If Delegation was also set, the two values must agree.
+				if effectivePrincipal != "" && effectivePrincipal != onBehalfOf {
+					return fmt.Errorf(
+						"authorization delegation principal mismatch: delegation.principalId %q "+
+							"does not match resources.onBehalfOf %q",
+						effectivePrincipal, onBehalfOf,
+					)
+				}
+				effectivePrincipal = onBehalfOf
 			}
+		}
+
+		if effectivePrincipal == principalID {
+			found = true
+			break
 		}
 	}
 	if !found {
 		return fmt.Errorf(
-			"at least one authorization must include {\"onBehalfOf\": \"%s\"} "+
+			"at least one authorization must include onBehalfOf = %q "+
+				"(via resources or delegation.principalId) "+
 				"to register a delegate for the data principal", principalID)
 	}
 

--- a/consent-server/internal/consent/validator/consent.go
+++ b/consent-server/internal/consent/validator/consent.go
@@ -236,9 +236,10 @@ func IsConsentExpired(validityTime int64) bool {
 // Rules enforced:
 //  1. delegation.principal_id must be provided
 //  2. The caller (X-User-ID) must NOT equal the principal_id — cannot self-delegate
-//  3. guardian.valid_until — OPTIONAL. When provided it must be a future Unix timestamp.
-//     Omit for permanent delegations (power of attorney, permanent disability carer, etc.)
-//     where there is no natural expiry date.
+//  3. guardian.valid_until — OPTIONAL. When provided it must be a future Unix timestamp
+//     in seconds. Millisecond values are rejected to avoid delegations ~1000x longer
+//     than intended. Omit for permanent delegations (power of attorney, permanent
+//     disability carer, etc.) where there is no natural expiry date.
 //  4. guardian.revocation_policy must be set to a valid value
 //  5. At least one authorization must have onBehalfOf = principal_id
 func ValidateDelegationAttributes(
@@ -273,10 +274,10 @@ func ValidateDelegationAttributes(
 			"caller '%s' cannot be both the delegator and the data principal", callerID)
 	}
 
-	// When does this delegation expire
 	// guardian.valid_until is OPTIONAL — permanent delegations (e.g., power of attorney
 	// for a permanently disabled adult, court-ordered guardianship with no end date)
-	// may legitimately omit this field. When provided it must be a valid future timestamp.
+	// may legitimately omit this field. When provided it must be a valid future timestamp
+	// in seconds.
 	validUntilStr := strings.TrimSpace(attributes[model.AttrGuardianValidUntil])
 	if validUntilStr != "" {
 		validUntil, err := strconv.ParseInt(validUntilStr, 10, 64)
@@ -301,18 +302,26 @@ func ValidateDelegationAttributes(
 	}
 
 	// Who is allowed to revoke this consent?
+	// Use model constants in error messages so they stay in sync if the constants are renamed.
 	policy := strings.TrimSpace(attributes[model.AttrGuardianRevocationPolicy])
 	if policy == "" {
 		return fmt.Errorf(
-			"guardian.revocation_policy is required for delegated consents; " +
-				"valid values: ANY, SUBJECT_ONLY")
+			"guardian.revocation_policy is required for delegated consents; "+
+				"valid values: %s, %s",
+			model.RevocationPolicyAny,
+			model.RevocationPolicySubjectOnly,
+		)
 	}
 	switch model.RevocationPolicy(policy) {
 	case model.RevocationPolicyAny, model.RevocationPolicySubjectOnly:
-		// valid — continue
+
 	default:
 		return fmt.Errorf(
-			"guardian.revocation_policy must be ANY or SUBJECT_ONLY, got: %s", policy)
+			"guardian.revocation_policy must be %s or %s, got: %s",
+			model.RevocationPolicyAny,
+			model.RevocationPolicySubjectOnly,
+			policy,
+		)
 	}
 
 	// At least one authorization must register a delegate for the principal.

--- a/consent-server/internal/consent/validator/consent.go
+++ b/consent-server/internal/consent/validator/consent.go
@@ -78,24 +78,11 @@ func ValidateConsentCreateRequest(req model.ConsentAPIRequest, clientID, orgID s
 // ValidateConsentUpdateRequest validates consent update request (keeping for future use)
 func ValidateConsentUpdateRequest(req model.ConsentAPIUpdateRequest) error {
 	// At least one field must be provided (check if nil, not if empty)
-	// Empty arrays are valid - they indicate removal of all items
 	if req.Type == "" && req.Frequency == nil &&
 		req.ValidityTime == nil && req.RecurringIndicator == nil &&
 		req.Attributes == nil && req.Authorizations == nil && req.Purposes == nil &&
-		req.DataAccessValidityDuration == nil && !req.ConvertToSelfConsent {
+		req.DataAccessValidityDuration == nil {
 		return fmt.Errorf("at least one field must be provided for update")
-	}
-
-	// convertToSelfConsent is an exclusive operation — it cannot be combined
-	// with other consent field updates. The conversion only deletes delegation
-	// metadata; any other changes must be made in a separate update call.
-	if req.ConvertToSelfConsent &&
-		(req.Type != "" || req.Frequency != nil ||
-			req.ValidityTime != nil || req.RecurringIndicator != nil ||
-			req.Attributes != nil || req.Authorizations != nil || req.Purposes != nil ||
-			req.DataAccessValidityDuration != nil) {
-		return fmt.Errorf("convertToSelfConsent cannot be combined with other consent updates; " +
-			"perform the conversion first, then update other fields separately")
 	}
 
 	// Validate Type length if provided (match create constraint)
@@ -114,25 +101,18 @@ func ValidateConsentUpdateRequest(req model.ConsentAPIUpdateRequest) error {
 	}
 
 	// Delegation attributes are immutable after consent creation.
-	// Blocking overwrite prevents a caller from extending guardian.valid_until
-	// indefinitely or changing the revocation policy after the fact.
-	// Exception: convertToSelfConsent bypasses this guard because the attrs
-	// are being DELETED entirely (not modified). The service layer validates
-	// that the caller is the principal and the delegation has expired.
-	if !req.ConvertToSelfConsent {
-		protectedKeys := []string{
-			model.AttrDelegationType,
-			model.AttrDelegationPrincipalID,
-			model.AttrGuardianValidUntil,
-			model.AttrGuardianRevocationPolicy,
-		}
-		if req.Attributes != nil {
-			for _, key := range protectedKeys {
-				if _, exists := req.Attributes[key]; exists {
-					return fmt.Errorf(
-						"delegation attribute '%s' is immutable after consent creation "+
-							"and cannot be modified via update", key)
-				}
+	protectedKeys := []string{
+		model.AttrDelegationType,
+		model.AttrDelegationPrincipalID,
+		model.AttrGuardianValidUntil,
+		model.AttrGuardianRevocationPolicy,
+	}
+	if req.Attributes != nil {
+		for _, key := range protectedKeys {
+			if _, exists := req.Attributes[key]; exists {
+				return fmt.Errorf(
+					"delegation attribute '%s' is immutable after consent creation "+
+						"and cannot be modified via update", key)
 			}
 		}
 	}
@@ -263,24 +243,8 @@ func IsConsentExpired(validityTime int64) bool {
 	return currentTimeMillis > validityTimeMillis
 }
 
-// ValidateDelegationAttributes validates the delegation-specific attributes on a
-// consent creation request when delegation.type is present in the request attributes.
-//
-// This is called from CreateConsent in service.go. It is a no-op when no
-// delegation.type attribute is set (normal self-consented request).
-//
-// Rules enforced:
-//  1. delegation.principal_id must be provided
-//  2. No delegate (auth.UserID) may equal the principal_id — that is circular.
-//     The caller may legitimately be the principal when proactively setting up
-//     delegation over their own data (e.g. capable adult initiating power of attorney).
-//  3. guardian.valid_until — OPTIONAL. When provided it must be a future Unix timestamp
-//     in seconds. Millisecond values are rejected to avoid delegations ~1000x longer
-//     than intended. Omit for permanent delegations (power of attorney, permanent
-//     disability carer, etc.) where there is no natural expiry date.
-//  4. guardian.revocation_policy must be set to a valid value
-//  5. At least one authorization must have onBehalfOf = principal_id, sourced from
-//     either auth.Resources["onBehalfOf"] or auth.Delegation.PrincipalID
+// ValidateDelegationAttributes validates delegation attributes when delegation.type is present.
+// No-op for normal self-consented requests.
 func ValidateDelegationAttributes(
 	attributes map[string]string,
 	authorizations []model.AuthorizationAPIRequest,
@@ -291,8 +255,7 @@ func ValidateDelegationAttributes(
 	if delegationType == "" {
 		return nil
 	}
-	// Lowercase copy for case-insensitive comparisons; the original
-	// delegationType is preserved for storage and error messages.
+	// Case-insensitive copy for comparisons.
 	delegationTypeLower := strings.ToLower(delegationType)
 
 	principalID := strings.TrimSpace(attributes[model.AttrDelegationPrincipalID])
@@ -301,18 +264,14 @@ func ValidateDelegationAttributes(
 			"delegation.principal_id is required when delegation.type is set")
 	}
 
-	// Without it we cannot enforce the self-delegation check below, so we must
-	// reject the request rather than silently skip the guard.
+	// Required for self-delegation check.
 	callerID = strings.TrimSpace(callerID)
 	if callerID == "" {
 		return fmt.Errorf(
 			"caller identity (X-User-ID) is required when delegation.type is set")
 	}
 
-	// The delegate being granted authority must not be the same as the data principal.
-	// That would be circular — a person cannot be delegated authority over their own consent.
-	// The caller MAY be the principal: a capable adult proactively setting up power of
-	// attorney for someone else over their own data is a valid real-world scenario.
+	// Delegate userId must not equal the principal (circular self-delegation).
 	for _, auth := range authorizations {
 		delegateUserID := strings.TrimSpace(auth.UserID)
 		if delegateUserID != "" && delegateUserID == principalID {
@@ -323,8 +282,7 @@ func ValidateDelegationAttributes(
 		}
 	}
 
-	// If the caller IS the principal, at least one real delegate with a different
-	// userId must be registered — otherwise there is no actual delegation happening.
+	// If caller is the principal, at least one other delegate must exist.
 	if callerID == principalID {
 		// Guard against a minor self-initiating parental consent.
 		// Parental delegation must be initiated by the parent, not the child, per
@@ -354,10 +312,6 @@ func ValidateDelegationAttributes(
 		}
 	}
 
-	// guardian.valid_until is OPTIONAL — permanent delegations (e.g., power of attorney
-	// for a permanently disabled adult, court-ordered guardianship with no end date)
-	// may legitimately omit this field. When provided it must be a valid future timestamp
-	// in seconds.
 	validUntilStr := strings.TrimSpace(attributes[model.AttrGuardianValidUntil])
 	if validUntilStr != "" {
 		validUntil, err := strconv.ParseInt(validUntilStr, 10, 64)
@@ -381,8 +335,7 @@ func ValidateDelegationAttributes(
 		}
 	}
 
-	// Who is allowed to revoke this consent?
-	// Use model constants in error messages so they stay in sync if the constants are renamed.
+	// Validate revocation policy.
 	policy := strings.TrimSpace(attributes[model.AttrGuardianRevocationPolicy])
 	if policy == "" {
 		return fmt.Errorf(
@@ -408,14 +361,9 @@ func ValidateDelegationAttributes(
 		)
 	}
 
-	// At least one authorization must register a delegate for the principal.
+	// At least one authorization must have onBehalfOf matching the principal.
 	//
-	// The principal can be identified via two paths:
-	//   1. auth.Resources["onBehalfOf"]  — legacy / direct JSON field
-	//   2. auth.Delegation.PrincipalID   — new typed delegation struct
 	//
-	// When both are present they must agree; a mismatch means the caller is
-	// trying to validate one principal and persist another.
 	found := false
 	for _, auth := range authorizations {
 		// Resolve the effective principal from the Delegation struct (new path).

--- a/consent-server/internal/consent/validator/consent.go
+++ b/consent-server/internal/consent/validator/consent.go
@@ -20,6 +20,7 @@ package validator
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -224,4 +225,94 @@ func IsConsentExpired(validityTime int64) bool {
 
 	currentTimeMillis := time.Now().UnixNano() / int64(time.Millisecond)
 	return currentTimeMillis > validityTimeMillis
+}
+
+// ValidateDelegationAttributes validates the delegation-specific attributes on a
+// consent creation request when delegation.type is present in the request attributes.
+//
+// This is called from CreateConsent in service.go. It is a no-op when no
+// delegation.type attribute is set (normal self-consented request).
+//
+// Rules enforced:
+//  1. delegation.principal_id must be provided
+//  2. The caller (X-User-ID) must NOT equal the principal_id — cannot self-delegate
+//  3. guardian.valid_until — OPTIONAL. When provided it must be a future Unix timestamp.
+//     Omit for permanent delegations (power of attorney, permanent disability carer, etc.)
+//     where there is no natural expiry date.
+//  4. guardian.revocation_policy must be set to a valid value
+//  5. At least one authorization must have onBehalfOf = principal_id
+func ValidateDelegationAttributes(
+	attributes map[string]string,
+	authorizations []model.AuthorizationAPIRequest,
+	callerID string,
+) error {
+	// Not a delegated consent — skip all delegation checks.
+	delegationType := attributes[model.AttrDelegationType]
+	if strings.TrimSpace(delegationType) == "" {
+		return nil
+	}
+
+	principalID := strings.TrimSpace(attributes[model.AttrDelegationPrincipalID])
+	if principalID == "" {
+		return fmt.Errorf(
+			"delegation.principal_id is required when delegation.type is set")
+	}
+
+	// The person giving consent must not be the same as the data subject.
+	// Applies to all delegation types: parental, carer, power-of-attorney, etc.
+	if callerID != "" && callerID == principalID {
+		return fmt.Errorf(
+			"caller '%s' cannot be both the delegator and the data principal", callerID)
+	}
+
+	// When does this delegation expire
+	// guardian.valid_until is OPTIONAL — permanent delegations (e.g., power of attorney
+	// for a permanently disabled adult, court-ordered guardianship with no end date)
+	// may legitimately omit this field. When provided it must be a valid future timestamp.
+	validUntilStr := strings.TrimSpace(attributes[model.AttrGuardianValidUntil])
+	if validUntilStr != "" {
+		validUntil, err := strconv.ParseInt(validUntilStr, 10, 64)
+		if err != nil || validUntil <= 0 {
+			return fmt.Errorf(
+				"guardian.valid_until must be a valid positive Unix timestamp in seconds")
+		}
+		if time.Now().Unix() >= validUntil {
+			return fmt.Errorf(
+				"guardian.valid_until must be a future timestamp; " +
+					"the delegation would be expired immediately")
+		}
+	}
+
+	// Who is allowed to revoke this consent?
+	policy := strings.TrimSpace(attributes[model.AttrGuardianRevocationPolicy])
+	if policy == "" {
+		return fmt.Errorf(
+			"guardian.revocation_policy is required for delegated consents; " +
+				"valid values: ANY, SUBJECT_ONLY")
+	}
+	switch model.RevocationPolicy(policy) {
+	case model.RevocationPolicyAny, model.RevocationPolicySubjectOnly:
+		// valid — continue
+	default:
+		return fmt.Errorf(
+			"guardian.revocation_policy must be ANY or SUBJECT_ONLY, got: %s", policy)
+	}
+
+	// At least one authorization must register a delegate for the principal.
+	found := false
+	for _, auth := range authorizations {
+		if resources, ok := auth.Resources.(map[string]interface{}); ok {
+			if onBehalfOf, _ := resources["onBehalfOf"].(string); onBehalfOf == principalID {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		return fmt.Errorf(
+			"at least one authorization must include {\"onBehalfOf\": \"%s\"} "+
+				"to register a delegate for the data principal", principalID)
+	}
+
+	return nil
 }

--- a/consent-server/internal/consent/validator/consent_test.go
+++ b/consent-server/internal/consent/validator/consent_test.go
@@ -19,7 +19,9 @@
 package validator
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/wso2/openfgc/internal/consent/model"
@@ -184,4 +186,134 @@ func TestValidateConsentUpdateRequest_MissingAuthType(t *testing.T) {
 	err := ValidateConsentUpdateRequest(req)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "authorizations[0].type is required")
+}
+
+// TestValidateConsentUpdateRequest_DelegationAttrImmutable_Type blocks delegation.type overwrite
+func TestValidateConsentUpdateRequest_DelegationAttrImmutable_Type(t *testing.T) {
+	req := model.ConsentAPIUpdateRequest{
+		Attributes: map[string]string{
+			"delegation.type": "parental_biological",
+		},
+	}
+	err := ValidateConsentUpdateRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "immutable")
+}
+
+// TestValidateConsentUpdateRequest_DelegationAttrImmutable_PrincipalID blocks principal_id overwrite
+func TestValidateConsentUpdateRequest_DelegationAttrImmutable_PrincipalID(t *testing.T) {
+	req := model.ConsentAPIUpdateRequest{
+		Attributes: map[string]string{
+			"delegation.principal_id": "child-user-123",
+		},
+	}
+	err := ValidateConsentUpdateRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "immutable")
+}
+
+// TestValidateConsentUpdateRequest_DelegationAttrImmutable_ValidUntil blocks valid_until overwrite
+func TestValidateConsentUpdateRequest_DelegationAttrImmutable_ValidUntil(t *testing.T) {
+	req := model.ConsentAPIUpdateRequest{
+		Attributes: map[string]string{
+			"guardian.valid_until": "9999999999",
+		},
+	}
+	err := ValidateConsentUpdateRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "immutable")
+}
+
+// TestValidateConsentUpdateRequest_DelegationAttrImmutable_RevocationPolicy blocks policy overwrite
+func TestValidateConsentUpdateRequest_DelegationAttrImmutable_RevocationPolicy(t *testing.T) {
+	req := model.ConsentAPIUpdateRequest{
+		Attributes: map[string]string{
+			"guardian.revocation_policy": "SUBJECT_ONLY",
+		},
+	}
+	err := ValidateConsentUpdateRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "immutable")
+}
+
+// TestValidateConsentUpdateRequest_NonDelegationAttr_Allowed allows normal attribute updates
+func TestValidateConsentUpdateRequest_NonDelegationAttr_Allowed(t *testing.T) {
+	req := model.ConsentAPIUpdateRequest{
+		Attributes: map[string]string{
+			"custom.attribute": "some-value",
+		},
+	}
+	err := ValidateConsentUpdateRequest(req)
+	require.NoError(t, err)
+}
+
+// TestValidateDelegation_MinorCannotSelfInitiateParental ensures a minor (caller == principal)
+// cannot self-initiate a parental delegation. Only the parent can initiate parental consent.
+func TestValidateDelegation_MinorCannotSelfInitiateParental(t *testing.T) {
+	attrs := map[string]string{
+		model.AttrDelegationType:           "parental_biological",
+		model.AttrDelegationPrincipalID:    "child-123",
+		model.AttrGuardianValidUntil:       fmt.Sprintf("%d", time.Now().Add(5*365*24*time.Hour).Unix()),
+		model.AttrGuardianRevocationPolicy: string(model.RevocationPolicyAny),
+	}
+	auths := []model.AuthorizationAPIRequest{
+		{UserID: "parent-456", Type: "PRIMARY", Delegation: &model.DelegationAPIRequest{
+			PrincipalID: "child-123", Type: "parental_biological", CanRevoke: true, CanModify: true,
+		}},
+	}
+
+	// Case 1: Caller == principal (child trying to self-initiate) — must fail
+	err := ValidateDelegationAttributes(attrs, auths, "child-123")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be initiated by the parent")
+
+	// Case 2: Caller != principal (parent initiating) — must pass
+	err = ValidateDelegationAttributes(attrs, auths, "parent-456")
+	require.NoError(t, err)
+}
+
+// TestValidateDelegation_NonParentalDelegation_CallerCanBePrincipal ensures that
+// non-parental delegation types (guardian, carer, power_of_attorney) allow a capable
+// adult to proactively initiate delegation over their own data.
+func TestValidateDelegation_NonParentalDelegation_CallerCanBePrincipal(t *testing.T) {
+	attrs := map[string]string{
+		model.AttrDelegationType:           "power_of_attorney",
+		model.AttrDelegationPrincipalID:    "adult-123",
+		model.AttrGuardianValidUntil:       fmt.Sprintf("%d", time.Now().Add(10*365*24*time.Hour).Unix()),
+		model.AttrGuardianRevocationPolicy: string(model.RevocationPolicyBoth),
+	}
+	auths := []model.AuthorizationAPIRequest{
+		{UserID: "attorney-456", Type: "PRIMARY", Delegation: &model.DelegationAPIRequest{
+			PrincipalID: "adult-123", Type: "power_of_attorney", CanRevoke: true, CanModify: true,
+		}},
+	}
+
+	// Caller == principal, but delegation type is power_of_attorney (not parental) — must pass
+	// This is a valid scenario: a capable adult setting up PoA over their own data.
+	err := ValidateDelegationAttributes(attrs, auths, "adult-123")
+	require.NoError(t, err)
+}
+
+// TestValidateConsentUpdateRequest_ConvertToSelfConsent_BypassesImmutability verifies
+// that convertToSelfConsent=true skips the delegation attribute immutability guard,
+// because the service layer will handle the actual deletion and validation.
+func TestValidateConsentUpdateRequest_ConvertToSelfConsent_BypassesImmutability(t *testing.T) {
+	// With convertToSelfConsent=false, sending delegation attrs in an update must FAIL
+	reqBlocked := model.ConsentAPIUpdateRequest{
+		Attributes: map[string]string{
+			model.AttrDelegationType: "parental_biological",
+		},
+	}
+	reqBlocked.ConvertToSelfConsent = false
+	err := ValidateConsentUpdateRequest(reqBlocked)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "immutable after consent creation")
+
+	// With convertToSelfConsent=true, the SAME request must PASS the validator
+	// (service layer does the real checks: expired? principal? delegated?)
+	reqAllowed := model.ConsentAPIUpdateRequest{
+		ConvertToSelfConsent: true,
+	}
+	err = ValidateConsentUpdateRequest(reqAllowed)
+	require.NoError(t, err)
 }

--- a/consent-server/internal/consent/validator/consent_test.go
+++ b/consent-server/internal/consent/validator/consent_test.go
@@ -249,7 +249,6 @@ func TestValidateConsentUpdateRequest_NonDelegationAttr_Allowed(t *testing.T) {
 
 // TestValidateDelegation_MinorCannotSelfInitiateParental ensures a minor (caller == principal)
 // cannot self-initiate a parental delegation. Only the parent can initiate parental consent.
-// This enforces Feedback 1 from the DPDP scenario.
 func TestValidateDelegation_MinorCannotSelfInitiateParental(t *testing.T) {
 	attrs := map[string]string{
 		model.AttrDelegationType:           "parental_biological",
@@ -310,15 +309,23 @@ func TestValidateConsentUpdateRequest_ConvertToSelfConsent_BypassesImmutability(
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "immutable after consent creation")
 
-	// With convertToSelfConsent=true, the SAME request must PASS the validator
+	// With convertToSelfConsent=true and NO other fields, the validator must PASS
 	// (service layer does the real checks: expired? principal? delegated?)
-	// Include protected delegation attributes to explicitly verify the bypass.
 	reqAllowed := model.ConsentAPIUpdateRequest{
+		ConvertToSelfConsent: true,
+	}
+	err = ValidateConsentUpdateRequest(reqAllowed)
+	require.NoError(t, err)
+
+	// convertToSelfConsent=true combined with other fields must FAIL
+	// (conversion is an exclusive operation)
+	reqMixed := model.ConsentAPIUpdateRequest{
 		ConvertToSelfConsent: true,
 		Attributes: map[string]string{
 			model.AttrDelegationType: "parental_biological",
 		},
 	}
-	err = ValidateConsentUpdateRequest(reqAllowed)
-	require.NoError(t, err)
+	err = ValidateConsentUpdateRequest(reqMixed)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "convertToSelfConsent cannot be combined")
 }

--- a/consent-server/internal/consent/validator/consent_test.go
+++ b/consent-server/internal/consent/validator/consent_test.go
@@ -249,6 +249,7 @@ func TestValidateConsentUpdateRequest_NonDelegationAttr_Allowed(t *testing.T) {
 
 // TestValidateDelegation_MinorCannotSelfInitiateParental ensures a minor (caller == principal)
 // cannot self-initiate a parental delegation. Only the parent can initiate parental consent.
+// This enforces Feedback 1 from the DPDP scenario.
 func TestValidateDelegation_MinorCannotSelfInitiateParental(t *testing.T) {
 	attrs := map[string]string{
 		model.AttrDelegationType:           "parental_biological",
@@ -311,8 +312,12 @@ func TestValidateConsentUpdateRequest_ConvertToSelfConsent_BypassesImmutability(
 
 	// With convertToSelfConsent=true, the SAME request must PASS the validator
 	// (service layer does the real checks: expired? principal? delegated?)
+	// Include protected delegation attributes to explicitly verify the bypass.
 	reqAllowed := model.ConsentAPIUpdateRequest{
 		ConvertToSelfConsent: true,
+		Attributes: map[string]string{
+			model.AttrDelegationType: "parental_biological",
+		},
 	}
 	err = ValidateConsentUpdateRequest(reqAllowed)
 	require.NoError(t, err)

--- a/consent-server/internal/consent/validator/consent_test.go
+++ b/consent-server/internal/consent/validator/consent_test.go
@@ -293,39 +293,3 @@ func TestValidateDelegation_NonParentalDelegation_CallerCanBePrincipal(t *testin
 	err := ValidateDelegationAttributes(attrs, auths, "adult-123")
 	require.NoError(t, err)
 }
-
-// TestValidateConsentUpdateRequest_ConvertToSelfConsent_BypassesImmutability verifies
-// that convertToSelfConsent=true skips the delegation attribute immutability guard,
-// because the service layer will handle the actual deletion and validation.
-func TestValidateConsentUpdateRequest_ConvertToSelfConsent_BypassesImmutability(t *testing.T) {
-	// With convertToSelfConsent=false, sending delegation attrs in an update must FAIL
-	reqBlocked := model.ConsentAPIUpdateRequest{
-		Attributes: map[string]string{
-			model.AttrDelegationType: "parental_biological",
-		},
-	}
-	reqBlocked.ConvertToSelfConsent = false
-	err := ValidateConsentUpdateRequest(reqBlocked)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "immutable after consent creation")
-
-	// With convertToSelfConsent=true and NO other fields, the validator must PASS
-	// (service layer does the real checks: expired? principal? delegated?)
-	reqAllowed := model.ConsentAPIUpdateRequest{
-		ConvertToSelfConsent: true,
-	}
-	err = ValidateConsentUpdateRequest(reqAllowed)
-	require.NoError(t, err)
-
-	// convertToSelfConsent=true combined with other fields must FAIL
-	// (conversion is an exclusive operation)
-	reqMixed := model.ConsentAPIUpdateRequest{
-		ConvertToSelfConsent: true,
-		Attributes: map[string]string{
-			model.AttrDelegationType: "parental_biological",
-		},
-	}
-	err = ValidateConsentUpdateRequest(reqMixed)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "convertToSelfConsent cannot be combined")
-}

--- a/consent-server/internal/system/stores/interfaces/store_interfaces.go
+++ b/consent-server/internal/system/stores/interfaces/store_interfaces.go
@@ -42,7 +42,6 @@ type ConsentStore interface {
 	UpdateStatus(tx dbmodel.TxInterface, consentID, orgID, status string, updatedTime int64) error
 	CreateAttributes(tx dbmodel.TxInterface, attributes []consentModel.ConsentAttribute) error
 	DeleteAttributesByConsentID(tx dbmodel.TxInterface, consentID, orgID string) error
-	DeleteAttributeByKey(tx dbmodel.TxInterface, consentID, attKey, orgID string) error
 	CreateStatusAudit(tx dbmodel.TxInterface, audit *consentModel.ConsentStatusAudit) error
 
 	CreateConsentPurposeMapping(tx dbmodel.TxInterface, consentID, purposeID, orgID string) error

--- a/consent-server/internal/system/stores/interfaces/store_interfaces.go
+++ b/consent-server/internal/system/stores/interfaces/store_interfaces.go
@@ -42,6 +42,7 @@ type ConsentStore interface {
 	UpdateStatus(tx dbmodel.TxInterface, consentID, orgID, status string, updatedTime int64) error
 	CreateAttributes(tx dbmodel.TxInterface, attributes []consentModel.ConsentAttribute) error
 	DeleteAttributesByConsentID(tx dbmodel.TxInterface, consentID, orgID string) error
+	DeleteAttributeByKey(tx dbmodel.TxInterface, consentID, attKey, orgID string) error
 	CreateStatusAudit(tx dbmodel.TxInterface, audit *consentModel.ConsentStatusAudit) error
 
 	CreateConsentPurposeMapping(tx dbmodel.TxInterface, consentID, purposeID, orgID string) error

--- a/consent-server/internal/system/utils/httputil.go
+++ b/consent-server/internal/system/utils/httputil.go
@@ -118,6 +118,14 @@ func mapErrorToStatusCode(err *serviceerror.ServiceError) int {
 		return http.StatusNotFound
 	}
 
+	// Forbidden — delegation and authorization errors
+	// CS-4051 (NotAuthorizedForPrincipal), CS-4052 (RevocationNotPermitted),
+	// CS-4053 (DelegationExpired), CS-4054 (Unauthorized)
+	if strings.HasSuffix(err.Code, "4051") || strings.HasSuffix(err.Code, "4052") ||
+		strings.HasSuffix(err.Code, "4053") || strings.HasSuffix(err.Code, "4054") {
+		return http.StatusForbidden
+	}
+
 	// All other client errors default to BadRequest
 	return http.StatusBadRequest
 }

--- a/consent-server/internal/system/utils/httputil.go
+++ b/consent-server/internal/system/utils/httputil.go
@@ -121,8 +121,8 @@ func mapErrorToStatusCode(err *serviceerror.ServiceError) int {
 	// Forbidden — delegation and authorization errors
 	// CS-4051 (NotAuthorizedForPrincipal), CS-4052 (RevocationNotPermitted),
 	// CS-4053 (DelegationExpired), CS-4054 (Unauthorized)
-	if strings.HasSuffix(err.Code, "4051") || strings.HasSuffix(err.Code, "4052") ||
-		strings.HasSuffix(err.Code, "4053") || strings.HasSuffix(err.Code, "4054") {
+	if err.Code == "CS-4051" || err.Code == "CS-4052" ||
+		err.Code == "CS-4053" || err.Code == "CS-4054" {
 		return http.StatusForbidden
 	}
 

--- a/consent-server/internal/system/utils/httputil.go
+++ b/consent-server/internal/system/utils/httputil.go
@@ -120,9 +120,9 @@ func mapErrorToStatusCode(err *serviceerror.ServiceError) int {
 
 	// Forbidden — delegation and authorization errors
 	// CS-4051 (NotAuthorizedForPrincipal), CS-4052 (RevocationNotPermitted),
-	// CS-4053 (DelegationExpired), CS-4054 (Unauthorized)
+	// CS-4053 (DelegationExpired), CS-4054 (Forbidden), CS-4055 (ModificationNotPermitted)
 	if err.Code == "CS-4051" || err.Code == "CS-4052" ||
-		err.Code == "CS-4053" || err.Code == "CS-4054" {
+		err.Code == "CS-4053" || err.Code == "CS-4054" || err.Code == "CS-4055" {
 		return http.StatusForbidden
 	}
 


### PR DESCRIPTION
**Purpose**

Data protection laws (DPDP Section 9, GDPR Article 8, LGPD, PIPA) require third parties — parents, carers, attorneys, guardians — to manage consent on behalf of minors, incapacitated adults, and persons under guardianship. OpenFGC had no mechanism for this. The UN-backed GovStack Consent Building Block confirms delegation is an industry-wide gap.

**Goal**

Implement a generic, schema-free delegated consent mechanism in OpenFGC with per-delegate permissions, temporal expiry, a three-policy revocation matrix, and audit trail enrichment — requiring zero database schema changes and supporting any jurisdiction without code changes.

**Approach**

Four key-value pairs in the existing CONSENT_ATTRIBUTE table store all delegation metadata. Per-delegate canRevoke and canModify flags live in the existing CONSENT_AUTH_RESOURCE.RESOURCES JSON blob. The delegation.type field is free-form — the system never checks the value, only that it exists — so the same code handles parental, medical, legal, and financial scenarios. Caller identity comes exclusively from the X-User-ID header injected by the API Gateway. Delegation attributes are immutable after creation. When delegation expires, delegates are automatically blocked and the data holder application handles the transition.

**User Stories**

A parent can create consent on behalf of a child with multiple delegates, each having independent canModify and canRevoke permissions.

A delegate can toggle individual purposes on or off without revoking the entire consent.

Revocation respects the configured policy (ANY, SUBJECT_ONLY, BOTH), enforces canRevoke flags, and writes a structured audit marker recording who acted on whose behalf.

When delegation expires, all delegate actions (modify, revoke, view delegates) are automatically blocked. The principal regains full authority.

After expiry, the data holder application guides the principal to create new consent. The consent engine only records, enforces, and audits.

Delegations with no expiry (e.g., power of attorney) are supported by omitting guardian.valid_until.

A delegate can be configured with canModify: true but canRevoke: false, ensuring only the principal can terminate the consent.

GET /consents/{id}/delegates returns all delegate permissions, expiry state, and revocation policy. Expired delegates are blocked from this endpoint.

Parental delegation types are rejected if initiated by the child, enforcing the legal requirement that parental consent originates from the parent.

Specific error codes (CS-4050 through CS-4055) are returned for each delegation rule violation.