### PR TITLE
Add element and purpose display names to consent get response

### DIFF
--- a/api/consent-management-API.yaml
+++ b/api/consent-management-API.yaml
@@ -341,12 +341,17 @@ paths:
                     purposes:
                       - name: "Account management"
                         version: "v1"
+                        displayName: "Account management"
                         elements:
                           - name: "User email"
                             namespace: "default"
+                            version: "v1"
+                            displayName: "User email address"
                             approved: false
                           - name: "User address"
                             namespace: "default"
+                            version: "v1"
+                            displayName: "User postal address"
                             approved: false
                     createdTime: 1702900000000
                     updatedTime: 1702900000000
@@ -377,9 +382,12 @@ paths:
                     purposes:
                       - name: "Account management"
                         version: "v1"
+                        displayName: "Account management"
                         elements:
                           - name: "User email"
                             namespace: "default"
+                            version: "v1"
+                            displayName: "User email address"
                             approved: false
                     createdTime: 1702900000000
                     updatedTime: 1702900000000
@@ -2666,6 +2674,11 @@ components:
             The specific version of the purpose to bind this consent to (e.g., v1, v2).
             If not specified, the latest version is used.
           example: "v1"
+        displayName:
+          type: string
+          nullable: true
+          description: Human-readable display name of the purpose version. Present in responses; omitted in requests.
+          example: "Marketing Communication Preferences"
         elements:
           type: array
           description: |
@@ -2708,6 +2721,15 @@ components:
             Combined with `name`, uniquely identifies the element within the organization.
             If not provided, the `default` namespace is used.
           example: "personal"
+        version:
+          type: string
+          description: The version identifier of the consent element. Present in responses; omitted in requests.
+          example: "v1"
+        displayName:
+          type: string
+          nullable: true
+          description: Human-readable display name of the element version. Present in responses; omitted in requests.
+          example: "User email address"
         approved:
           type: boolean
           description: |
@@ -3078,15 +3100,20 @@ components:
           - purposeId: "550e8400-e29b-41d4-a716-446655440000"
             name: "marketing_communication_preferences"
             version: "v1"
+            displayName: "Marketing Communication Preferences"
             elements:
               - elementId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                 name: "user_email"
                 namespace: "personal"
+                version: "v1"
+                displayName: "User email address"
                 approved: true
                 value: {}
               - elementId: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
                 name: "user_mobile"
                 namespace: "personal"
+                version: "v1"
+                displayName: "User mobile number"
                 approved: true
                 value: {}
         createdTime: 1702800000000

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -546,20 +546,22 @@ func consentOutputToResponse(out *model.ConsentOutput) *model.ConsentResponse {
 		elements := make([]model.ConsentPurposeElementApprovalResponse, 0, len(p.Elements))
 		for _, e := range p.Elements {
 			elements = append(elements, model.ConsentPurposeElementApprovalResponse{
-				ElementID: e.ElementID,
-				Name:      e.Name,
-				Namespace: e.Namespace,
-				Version:   formatVersion(e.VersionNum),
-				Mandatory: e.Mandatory,
-				Approved:  e.Approved,
-				Value:     valueStringToInterface(e.Value, e.ElementType),
+				ElementID:   e.ElementID,
+				Name:        e.Name,
+				Namespace:   e.Namespace,
+				Version:     formatVersion(e.VersionNum),
+				DisplayName: e.DisplayName,
+				Mandatory:   e.Mandatory,
+				Approved:    e.Approved,
+				Value:       valueStringToInterface(e.Value, e.ElementType),
 			})
 		}
 		purposes = append(purposes, model.ConsentPurposeResponse{
-			PurposeID: p.PurposeID,
-			Name:      p.Name,
-			Version:   formatVersion(p.VersionNum),
-			Elements:  elements,
+			PurposeID:   p.PurposeID,
+			Name:        p.Name,
+			Version:     formatVersion(p.VersionNum),
+			DisplayName: p.DisplayName,
+			Elements:    elements,
 		})
 	}
 

--- a/consent-server/internal/consent/handler_test.go
+++ b/consent-server/internal/consent/handler_test.go
@@ -180,12 +180,27 @@ func TestHandlerCreateConsent_ServiceError(t *testing.T) {
 
 func TestHandlerGetConsent_Success(t *testing.T) {
 	mockSvc := NewMockConsentService(t)
+	purposeDisplayName := "Account management"
+	elementDisplayName := "User email address"
 
 	out := &model.ConsentOutput{
 		ConsentID:     handlerTestConsentID,
 		GroupID:       handlerTestGroupID,
 		ConsentType:   "accounts",
 		CurrentStatus: "ACTIVE",
+		Purposes: []model.ConsentPurposeOutput{{
+			PurposeID:   "purpose-1",
+			Name:        "account_management",
+			VersionNum:  1,
+			DisplayName: &purposeDisplayName,
+			Elements: []model.ConsentElementApprovalOutput{{
+				ElementID:   "element-1",
+				Name:        "user_email",
+				Namespace:   "default",
+				VersionNum:  1,
+				DisplayName: &elementDisplayName,
+			}},
+		}},
 	}
 	mockSvc.On("GetConsent", mock.Anything, handlerTestConsentID, handlerTestOrgID).Return(out, nil)
 
@@ -202,6 +217,8 @@ func TestHandlerGetConsent_Success(t *testing.T) {
 	var resp model.ConsentResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Equal(t, handlerTestConsentID, resp.ConsentID)
+	require.Equal(t, purposeDisplayName, *resp.Purposes[0].DisplayName)
+	require.Equal(t, elementDisplayName, *resp.Purposes[0].Elements[0].DisplayName)
 }
 
 func TestHandlerGetConsent_NotFound(t *testing.T) {
@@ -241,9 +258,25 @@ func TestHandlerGetConsent_MissingOrgID(t *testing.T) {
 
 func TestHandlerListConsents_Success(t *testing.T) {
 	mockSvc := NewMockConsentService(t)
+	purposeDisplayName := "Account management"
+	elementDisplayName := "User email address"
 
 	listOut := &model.ConsentListOutput{
-		Data:   []model.ConsentOutput{{ConsentID: handlerTestConsentID, ConsentType: "accounts", CurrentStatus: "ACTIVE"}},
+		Data: []model.ConsentOutput{{
+			ConsentID:     handlerTestConsentID,
+			ConsentType:   "accounts",
+			CurrentStatus: "ACTIVE",
+			Purposes: []model.ConsentPurposeOutput{{
+				Name:        "account_management",
+				VersionNum:  1,
+				DisplayName: &purposeDisplayName,
+				Elements: []model.ConsentElementApprovalOutput{{
+					Name:        "user_email",
+					VersionNum:  1,
+					DisplayName: &elementDisplayName,
+				}},
+			}},
+		}},
 		Total:  1,
 		Count:  1,
 		Offset: 0,
@@ -263,6 +296,8 @@ func TestHandlerListConsents_Success(t *testing.T) {
 	var resp model.ConsentListResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(t, resp.Data, 1)
+	require.Equal(t, purposeDisplayName, *resp.Data[0].Purposes[0].DisplayName)
+	require.Equal(t, elementDisplayName, *resp.Data[0].Purposes[0].Elements[0].DisplayName)
 }
 
 func TestHandlerListConsents_MissingOrgID(t *testing.T) {

--- a/consent-server/internal/consent/model/consent.go
+++ b/consent-server/internal/consent/model/consent.go
@@ -394,21 +394,23 @@ type ConsentValidateRequest struct {
 // ConsentPurposeElementApprovalResponse is one element in a consent purpose response.
 // Combines the element's definition with the user's approval state for this consent.
 type ConsentPurposeElementApprovalResponse struct {
-	ElementID string      `json:"elementId"`
-	Name      string      `json:"name"`
-	Namespace string      `json:"namespace"`
-	Version   string      `json:"version"` // "v1", "v2", ...
-	Mandatory bool        `json:"mandatory"`
-	Approved  bool        `json:"approved"`
-	Value     interface{} `json:"value,omitempty"`
+	ElementID   string      `json:"elementId"`
+	Name        string      `json:"name"`
+	Namespace   string      `json:"namespace"`
+	Version     string      `json:"version"` // "v1", "v2", ...
+	DisplayName *string     `json:"displayName,omitempty"`
+	Mandatory   bool        `json:"mandatory"`
+	Approved    bool        `json:"approved"`
+	Value       interface{} `json:"value,omitempty"`
 }
 
 // ConsentPurposeResponse is one purpose in a consent response (create/get/update).
 type ConsentPurposeResponse struct {
-	PurposeID string                                  `json:"purposeId"`
-	Name      string                                  `json:"name"`
-	Version   string                                  `json:"version"` // "v1", "v2", ...
-	Elements  []ConsentPurposeElementApprovalResponse `json:"elements"`
+	PurposeID   string                                  `json:"purposeId"`
+	Name        string                                  `json:"name"`
+	Version     string                                  `json:"version"` // "v1", "v2", ...
+	DisplayName *string                                 `json:"displayName,omitempty"`
+	Elements    []ConsentPurposeElementApprovalResponse `json:"elements"`
 }
 
 // AuthorizationResponse is one authorization in a consent response.


### PR DESCRIPTION
## Purpose

Enhance `GET /api/v1/consents/`  and `GET /api/v1/consents/{consentId}` responses with the human-readable display names of referenced purposes and element versions. 

## Goals

- Expose `purposes[].displayName`.
- Expose `purposes[].elements[].displayName`.
- Keep display names optional and omit them when not configured.
- Keep the OpenAPI specification consistent with the implementation and existing response conventions.

## Approach

Reuse the purpose and element display names already loaded by the consent service and map them into the regular consent response DTOs. Update the OpenAPI schemas and GET consent examples, including the existing element-level `version` field returned by the implementation.

## User stories

As an API consumer, I can display user-friendly purpose and consent element names when retrieving a consent without making additional purpose or element API calls.

## Release note

Consent retrieval responses now include optional display names for consent purposes and elements.

## Documentation

Updated `api/consent-management-API.yaml` with the response fields and examples.

## Automation tests

- Unit tests
  - `./build.sh test_unit` successfully executed.
  - Added handler coverage verifying purpose and element display names are serialized.
- Integration tests
  - Integration test suites successfully executed for both MySQL and SQLite.

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: no — not applicable to this Go change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples

Updated the `GET /api/v1/consents/`  and `GET /api/v1/consents/{consentId}` OpenAPI examples to show purpose and element display names.

## Test environment

- Windows
- Go toolchain
- Consent service unit tests
- Mysql/SQLite
