### PR TITLE
Display names in consent get and purpose get

### DIFF
--- a/api/consent-management-API.yaml
+++ b/api/consent-management-API.yaml
@@ -2051,11 +2051,15 @@ paths:
                         name: "user_email"
                         namespace: "personal"
                         version: "v1"
+                        displayName: "User email address"
+                        description: "The user's email address"
                         mandatory: true
                       - elementId: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
                         name: "user_mobile"
                         namespace: "personal"
                         version: "v2"
+                        displayName: "User mobile number"
+                        description: "The user's mobile phone number"
                         mandatory: false
                     createdTime: 1742860800000
         "400":
@@ -2252,11 +2256,15 @@ paths:
                             name: "user_email"
                             namespace: "personal"
                             version: "v1"
+                            displayName: "User email address"
+                            description: "The user's email address"
                             mandatory: true
                           - elementId: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
                             name: "user_mobile"
                             namespace: "personal"
                             version: "v2"
+                            displayName: "User mobile number"
+                            description: "The user's mobile phone number"
                             mandatory: false
                         createdTime: 1736467200000
                     metadata:
@@ -2338,16 +2346,22 @@ paths:
                     name: "user_email"
                     namespace: "personal"
                     version: "v1"
+                    displayName: "User email address"
+                    description: "The user's email address"
                     mandatory: true
                   - elementId: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
                     name: "user_mobile"
                     namespace: "personal"
                     version: "v2"
+                    displayName: "User mobile number"
+                    description: "The user's mobile phone number"
                     mandatory: false
                   - elementId: "c3d4e5f6-a7b8-9012-cdef-123456789012"
                     name: "user_address"
                     namespace: "personal"
                     version: "v1"
+                    displayName: "User address"
+                    description: "The user's address"
                     mandatory: false
                 createdTime: 1736467200000
         "404":
@@ -2420,16 +2434,22 @@ paths:
                         name: "user_email"
                         namespace: "personal"
                         version: "v1"
+                        displayName: "User email address"
+                        description: "The user's email address"
                         mandatory: true
                       - elementId: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
                         name: "user_mobile"
                         namespace: "personal"
                         version: "v2"
+                        displayName: "User mobile number"
+                        description: "The user's mobile phone number"
                         mandatory: false
                       - elementId: "c3d4e5f6-a7b8-9012-cdef-123456789012"
                         name: "user_address"
                         namespace: "personal"
                         version: "v1"
+                        displayName: "User address"
+                        description: "The user's address"
                         mandatory: false
                     createdTime: 1740787200000
                   - version: "v1"
@@ -2443,11 +2463,15 @@ paths:
                         name: "user_email"
                         namespace: "personal"
                         version: "v1"
+                        displayName: "User email address"
+                        description: "The user's email address"
                         mandatory: true
                       - elementId: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
                         name: "user_mobile"
                         namespace: "personal"
                         version: "v1"
+                        displayName: "User mobile number"
+                        description: "The user's mobile phone number"
                         mandatory: false
                     createdTime: 1736467200000
         "404":
@@ -2547,11 +2571,15 @@ paths:
                     name: "patient_name"
                     namespace: "medical"
                     version: "v1"
+                    displayName: "Patient name"
+                    description: "The patient's name"
                     mandatory: true
                   - elementId: "e5f6a7b8-c9d0-1234-efab-345678901234"
                     name: "medical_history"
                     namespace: "medical"
                     version: "v2"
+                    displayName: "Medical history"
+                    description: "The patient's medical history"
                     mandatory: false
                 createdTime: 1740787200000
         "400":
@@ -2649,11 +2677,15 @@ paths:
                     name: "patient_name"
                     namespace: "medical"
                     version: "v1"
+                    displayName: "Patient name"
+                    description: "The patient's name"
                     mandatory: true
                   - elementId: "e5f6a7b8-c9d0-1234-efab-345678901234"
                     name: "medical_history"
                     namespace: "medical"
                     version: "v1"
+                    displayName: "Medical history"
+                    description: "The patient's medical history"
                     mandatory: false
                 createdTime: 1736467200000
         "404":
@@ -4853,6 +4885,16 @@ components:
           type: string
           description: The specific version of the element referenced in this purpose version (e.g., v1, v2)
           example: "v1"
+        displayName:
+          type: string
+          nullable: true
+          description: Human-readable display name of the element version.
+          example: "User email address"
+        description:
+          type: string
+          nullable: true
+          description: Description of the element version.
+          example: "The user's email address"
         mandatory:
           type: boolean
           description: |

--- a/api/consent-management-API.yaml
+++ b/api/consent-management-API.yaml
@@ -414,22 +414,28 @@ paths:
                   value:
                     id: "30000001-0003-0003-0003-000000000002"
                     purposes:
-                      - name: "Account management"
+                      - purposeId: "550e8400-e29b-41d4-a716-446655440000"
+                        name: "account_management"
                         version: "v1"
                         elements:
-                          - name: "User email"
+                          - elementId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                            name: "user_email"
                             namespace: "default"
                             version: "v1"
+                            mandatory: false
                             approved: false
-                          - name: "User address"
+                          - elementId: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+                            name: "user_address"
                             namespace: "default"
                             version: "v1"
+                            mandatory: false
                             approved: false
                     createdTime: 1702900000000
                     updatedTime: 1702900000000
                     groupId: "app-group-001"
                     type: "Account management"
                     status: "ACTIVE"
+                    frequency: 0
                     expirationTime: 1798741800000
                     recurringIndicator: true
                     dataAccessValidityDuration: 0
@@ -452,18 +458,22 @@ paths:
                   value:
                     id: "30000001-0003-0003-0003-000000000002"
                     purposes:
-                      - name: "Account management"
+                      - purposeId: "550e8400-e29b-41d4-a716-446655440000"
+                        name: "account_management"
                         version: "v1"
                         elements:
-                          - name: "User email"
+                          - elementId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                            name: "user_email"
                             namespace: "default"
                             version: "v1"
+                            mandatory: false
                             approved: false
                     createdTime: 1702900000000
                     updatedTime: 1702900000000
                     groupId: "app-group-001"
                     type: "Account management"
                     status: "ACTIVE"
+                    frequency: 0
                     expirationTime: 1798741800000
                     recurringIndicator: true
                     dataAccessValidityDuration: 0
@@ -498,28 +508,34 @@ paths:
                   value:
                     id: "30000001-0003-0003-0003-000000000002"
                     purposes:
-                      - name: "Account management"
+                      - purposeId: "550e8400-e29b-41d4-a716-446655440000"
+                        name: "account_management"
                         version: "v1"
                         displayName: "Account management"
                         description: "Manage account access"
                         elements:
-                          - name: "User email"
+                          - elementId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                            name: "user_email"
                             namespace: "default"
                             version: "v1"
                             displayName: "User email address"
                             description: "The user's email address"
+                            mandatory: false
                             approved: false
-                          - name: "User address"
+                          - elementId: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+                            name: "user_address"
                             namespace: "default"
                             version: "v1"
                             displayName: "User postal address"
                             description: "The user's postal address"
+                            mandatory: false
                             approved: false
                     createdTime: 1702900000000
                     updatedTime: 1702900000000
                     groupId: "app-group-001"
                     type: "Account management"
                     status: "ACTIVE"
+                    frequency: 0
                     expirationTime: 1798741800000
                     recurringIndicator: true
                     dataAccessValidityDuration: 0
@@ -3360,11 +3376,15 @@ components:
               - elementId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                 name: "user_email"
                 namespace: "personal"
+                version: "v1"
+                mandatory: true
                 approved: true
                 value: {}
               - elementId: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
                 name: "user_mobile"
                 namespace: "personal"
+                version: "v1"
+                mandatory: false
                 approved: true
                 value: {}
         createdTime: 1702800000000

--- a/api/consent-management-API.yaml
+++ b/api/consent-management-API.yaml
@@ -120,6 +120,9 @@ paths:
       summary: Search for consents
       description: |
         Provides a powerful search capability to find consents based on various filter criteria like consent type, status, group ID, user ID, purpose, and element. Supports pagination.
+        By default (`details=false`), purpose and element entries contain only their identifiers,
+        versions, and consent approval state. Set `details=true` to include the display name and
+        description for every purpose and element version.
         If purposeVersion is specified, purposeName must also be provided.
         If elementVersion is specified, at least one of elementName or elementNamespace must also be provided.
 
@@ -217,6 +220,12 @@ paths:
             type: integer
             format: int32
           example: 0
+        - name: details
+          in: query
+          description: Include purpose and element display names and descriptions when set to `true`.
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: OK. Returns a list of consents matching the search criteria, along with pagination metadata.
@@ -224,6 +233,63 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ConsentSearchResponse"
+              examples:
+                minimal:
+                  summary: Search response with details=false (default)
+                  value:
+                    data:
+                      - id: "30000001-0003-0003-0003-000000000002"
+                        groupId: "app-group-001"
+                        type: "Account management"
+                        status: "ACTIVE"
+                        createdTime: 1702900000000
+                        updatedTime: 1702900000000
+                        purposes:
+                          - purposeId: "550e8400-e29b-41d4-a716-446655440000"
+                            name: "account_management"
+                            version: "v1"
+                            elements:
+                              - elementId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                                name: "user_email"
+                                namespace: "default"
+                                version: "v1"
+                                mandatory: true
+                                approved: true
+                    metadata:
+                      total: 1
+                      offset: 0
+                      count: 1
+                      limit: 10
+                detailed:
+                  summary: Search response with details=true
+                  value:
+                    data:
+                      - id: "30000001-0003-0003-0003-000000000002"
+                        groupId: "app-group-001"
+                        type: "Account management"
+                        status: "ACTIVE"
+                        createdTime: 1702900000000
+                        updatedTime: 1702900000000
+                        purposes:
+                          - purposeId: "550e8400-e29b-41d4-a716-446655440000"
+                            name: "account_management"
+                            version: "v1"
+                            displayName: "Account management"
+                            description: "Manage account access"
+                            elements:
+                              - elementId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                                name: "user_email"
+                                namespace: "default"
+                                version: "v1"
+                                displayName: "User email address"
+                                description: "The user's email address"
+                                mandatory: true
+                                approved: true
+                    metadata:
+                      total: 1
+                      offset: 0
+                      count: 1
+                      limit: 10
         "400":
           description: Bad Request. The search parameters provided are invalid.
           content:
@@ -299,8 +365,10 @@ paths:
     get:
       summary: Retrieve a consent by its ID
       description: |
-        Fetches the complete details of a specific consent resource using
-        its unique `consentID`. This is used to check the status and details of a consent.
+        Fetches a specific consent resource using its unique `consentID`.
+        By default (`details=false`), purpose and element entries contain only their
+        identifiers, versions, and consent approval state. Set `details=true` to include
+        the display name and description for every purpose and element version.
 
       operationId: consents-GET
       tags:
@@ -326,32 +394,36 @@ paths:
           schema:
             type: boolean
             default: false
+        - in: query
+          name: details
+          required: false
+          description: Include purpose and element display names and descriptions when set to `true`.
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
-          description: OK. The full details of the requested consent are returned in the response body.
+          description: OK. Returns the requested consent, with purpose and element definition details controlled by the `details` query parameter.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ConsentRetrievalResponse"
               examples:
                 withoutStatusHistory:
-                  summary: Consent response without status history
+                  summary: Consent response without status history (details=false)
                   value:
                     id: "30000001-0003-0003-0003-000000000002"
                     purposes:
                       - name: "Account management"
                         version: "v1"
-                        displayName: "Account management"
                         elements:
                           - name: "User email"
                             namespace: "default"
                             version: "v1"
-                            displayName: "User email address"
                             approved: false
                           - name: "User address"
                             namespace: "default"
                             version: "v1"
-                            displayName: "User postal address"
                             approved: false
                     createdTime: 1702900000000
                     updatedTime: 1702900000000
@@ -376,18 +448,16 @@ paths:
                             - "acc-789"
                             - "acc-101"
                 withStatusHistory:
-                  summary: Consent response with status history
+                  summary: Consent response with status history (details=false)
                   value:
                     id: "30000001-0003-0003-0003-000000000002"
                     purposes:
                       - name: "Account management"
                         version: "v1"
-                        displayName: "Account management"
                         elements:
                           - name: "User email"
                             namespace: "default"
                             version: "v1"
-                            displayName: "User email address"
                             approved: false
                     createdTime: 1702900000000
                     updatedTime: 1702900000000
@@ -423,6 +493,50 @@ paths:
                         actionTime: 1745000000000
                         actionBy: "client-app-123"
                         reason: "Consent created"
+                withDetails:
+                  summary: Consent response with details=true (status history disabled)
+                  value:
+                    id: "30000001-0003-0003-0003-000000000002"
+                    purposes:
+                      - name: "Account management"
+                        version: "v1"
+                        displayName: "Account management"
+                        description: "Manage account access"
+                        elements:
+                          - name: "User email"
+                            namespace: "default"
+                            version: "v1"
+                            displayName: "User email address"
+                            description: "The user's email address"
+                            approved: false
+                          - name: "User address"
+                            namespace: "default"
+                            version: "v1"
+                            displayName: "User postal address"
+                            description: "The user's postal address"
+                            approved: false
+                    createdTime: 1702900000000
+                    updatedTime: 1702900000000
+                    groupId: "app-group-001"
+                    type: "Account management"
+                    status: "ACTIVE"
+                    expirationTime: 1798741800000
+                    recurringIndicator: true
+                    dataAccessValidityDuration: 0
+                    attributes:
+                      department: "customer_service"
+                      gdpr_compliant: "true"
+                      region: "EU"
+                    authorizations:
+                      - id: "a1b2c3d4-e5f6-7890-abcd-ef1234567891"
+                        userId: "user2@example.com"
+                        type: "authorisation"
+                        status: "APPROVED"
+                        updatedTime: 1702900000000
+                        resources:
+                          accountIds:
+                            - "acc-789"
+                            - "acc-101"
         "400":
           description: Bad Request. The request was invalid, possibly due to a malformed `consentID` or missing headers.
           content:
@@ -2677,8 +2791,13 @@ components:
         displayName:
           type: string
           nullable: true
-          description: Human-readable display name of the purpose version. Present in responses; omitted in requests.
+          description: Human-readable display name of the purpose version. Included in responses when `details=true`; omitted from minimal responses and requests.
           example: "Marketing Communication Preferences"
+        description:
+          type: string
+          nullable: true
+          description: Description of the purpose version. Included in responses when `details=true`; omitted from minimal responses and requests.
+          example: "Manage account access"
         elements:
           type: array
           description: |
@@ -2728,8 +2847,13 @@ components:
         displayName:
           type: string
           nullable: true
-          description: Human-readable display name of the element version. Present in responses; omitted in requests.
+          description: Human-readable display name of the element version. Included in responses when `details=true`; omitted from minimal responses and requests.
           example: "User email address"
+        description:
+          type: string
+          nullable: true
+          description: Description of the element version. Included in responses when `details=true`; omitted from minimal responses and requests.
+          example: "The user's email address"
         approved:
           type: boolean
           description: |
@@ -3100,20 +3224,17 @@ components:
           - purposeId: "550e8400-e29b-41d4-a716-446655440000"
             name: "marketing_communication_preferences"
             version: "v1"
-            displayName: "Marketing Communication Preferences"
             elements:
               - elementId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                 name: "user_email"
                 namespace: "personal"
                 version: "v1"
-                displayName: "User email address"
                 approved: true
                 value: {}
               - elementId: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
                 name: "user_mobile"
                 namespace: "personal"
                 version: "v1"
-                displayName: "User mobile number"
                 approved: true
                 value: {}
         createdTime: 1702800000000

--- a/consent-server/internal/consent/handler.go
+++ b/consent-server/internal/consent/handler.go
@@ -101,6 +101,7 @@ func (h *consentHandler) getConsent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	includeStatusHistory := r.URL.Query().Get("includeStatusHistory") == "true"
+	details := r.URL.Query().Get("details") == "true"
 	var out *model.ConsentOutput
 	var serviceErr *serviceerror.ServiceError
 	if includeStatusHistory {
@@ -114,7 +115,7 @@ func (h *consentHandler) getConsent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set(constants.HeaderContentType, constants.ContentTypeJSON)
-	json.NewEncoder(w).Encode(consentOutputToResponse(out))
+	json.NewEncoder(w).Encode(consentOutputToResponseWithDetails(out, details))
 }
 
 // getConsentHistory handles GET /consents/{consentId}/history
@@ -270,7 +271,8 @@ func (h *consentHandler) listConsents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set(constants.HeaderContentType, constants.ContentTypeJSON)
-	json.NewEncoder(w).Encode(consentListOutputToResponse(listOut))
+	details := r.URL.Query().Get("details") == "true"
+	json.NewEncoder(w).Encode(consentListOutputToResponse(listOut, details))
 }
 
 // updateConsent handles PUT /consents/{consentId}
@@ -537,6 +539,18 @@ func authorizationRequestToInput(ar model.AuthorizationRequest) authmodel.Create
 
 // consentOutputToResponse converts a ConsentOutput to the JSON-ready ConsentResponse.
 func consentOutputToResponse(out *model.ConsentOutput) *model.ConsentResponse {
+	// Preserve the existing create/update and internal snapshot response shape:
+	// display names are included, while descriptions remain GET/search details.
+	return consentOutputToResponseWithOptions(out, true, false)
+}
+
+// consentOutputToResponseWithDetails converts a ConsentOutput to a response and
+// includes purpose/element definition details only when requested.
+func consentOutputToResponseWithDetails(out *model.ConsentOutput, details bool) *model.ConsentResponse {
+	return consentOutputToResponseWithOptions(out, details, details)
+}
+
+func consentOutputToResponseWithOptions(out *model.ConsentOutput, includeDisplayNames, includeDescriptions bool) *model.ConsentResponse {
 	if out == nil {
 		return nil
 	}
@@ -545,22 +559,38 @@ func consentOutputToResponse(out *model.ConsentOutput) *model.ConsentResponse {
 	for _, p := range out.Purposes {
 		elements := make([]model.ConsentPurposeElementApprovalResponse, 0, len(p.Elements))
 		for _, e := range p.Elements {
+			var elementDisplayName, elementDescription *string
+			if includeDisplayNames {
+				elementDisplayName = e.DisplayName
+			}
+			if includeDescriptions {
+				elementDescription = e.Description
+			}
 			elements = append(elements, model.ConsentPurposeElementApprovalResponse{
 				ElementID:   e.ElementID,
 				Name:        e.Name,
 				Namespace:   e.Namespace,
 				Version:     formatVersion(e.VersionNum),
-				DisplayName: e.DisplayName,
+				DisplayName: elementDisplayName,
+				Description: elementDescription,
 				Mandatory:   e.Mandatory,
 				Approved:    e.Approved,
 				Value:       valueStringToInterface(e.Value, e.ElementType),
 			})
 		}
+		var purposeDisplayName, purposeDescription *string
+		if includeDisplayNames {
+			purposeDisplayName = p.DisplayName
+		}
+		if includeDescriptions {
+			purposeDescription = p.Description
+		}
 		purposes = append(purposes, model.ConsentPurposeResponse{
 			PurposeID:   p.PurposeID,
 			Name:        p.Name,
 			Version:     formatVersion(p.VersionNum),
-			DisplayName: p.DisplayName,
+			DisplayName: purposeDisplayName,
+			Description: purposeDescription,
 			Elements:    elements,
 		})
 	}
@@ -606,10 +636,10 @@ func consentOutputToResponse(out *model.ConsentOutput) *model.ConsentResponse {
 }
 
 // consentListOutputToResponse converts a ConsentListOutput to the JSON-ready ConsentListResponse.
-func consentListOutputToResponse(out *model.ConsentListOutput) *model.ConsentListResponse {
+func consentListOutputToResponse(out *model.ConsentListOutput, details bool) *model.ConsentListResponse {
 	data := make([]model.ConsentResponse, 0, len(out.Data))
 	for i := range out.Data {
-		r := consentOutputToResponse(&out.Data[i])
+		r := consentOutputToResponseWithDetails(&out.Data[i], details)
 		data = append(data, *r)
 	}
 	return &model.ConsentListResponse{

--- a/consent-server/internal/consent/handler_test.go
+++ b/consent-server/internal/consent/handler_test.go
@@ -181,7 +181,9 @@ func TestHandlerCreateConsent_ServiceError(t *testing.T) {
 func TestHandlerGetConsent_Success(t *testing.T) {
 	mockSvc := NewMockConsentService(t)
 	purposeDisplayName := "Account management"
+	purposeDescription := "Manage account access"
 	elementDisplayName := "User email address"
+	elementDescription := "The user's email address"
 
 	out := &model.ConsentOutput{
 		ConsentID:     handlerTestConsentID,
@@ -193,12 +195,53 @@ func TestHandlerGetConsent_Success(t *testing.T) {
 			Name:        "account_management",
 			VersionNum:  1,
 			DisplayName: &purposeDisplayName,
+			Description: &purposeDescription,
 			Elements: []model.ConsentElementApprovalOutput{{
 				ElementID:   "element-1",
 				Name:        "user_email",
 				Namespace:   "default",
 				VersionNum:  1,
 				DisplayName: &elementDisplayName,
+				Description: &elementDescription,
+			}},
+		}},
+	}
+	mockSvc.On("GetConsent", mock.Anything, handlerTestConsentID, handlerTestOrgID).Return(out, nil)
+
+	handler := newConsentHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/consents/"+handlerTestConsentID+"?details=true", nil)
+	req.Header.Set(constants.HeaderOrgID, handlerTestOrgID)
+	req.SetPathValue("consentId", handlerTestConsentID)
+	rr := httptest.NewRecorder()
+
+	handler.getConsent(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp model.ConsentResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Equal(t, handlerTestConsentID, resp.ConsentID)
+	require.Equal(t, purposeDisplayName, *resp.Purposes[0].DisplayName)
+	require.Equal(t, purposeDescription, *resp.Purposes[0].Description)
+	require.Equal(t, elementDisplayName, *resp.Purposes[0].Elements[0].DisplayName)
+	require.Equal(t, elementDescription, *resp.Purposes[0].Elements[0].Description)
+}
+
+func TestHandlerGetConsent_DefaultOmitsDefinitionDetails(t *testing.T) {
+	mockSvc := NewMockConsentService(t)
+	purposeDisplayName := "Account management"
+	purposeDescription := "Manage account access"
+	elementDisplayName := "User email address"
+	elementDescription := "The user's email address"
+
+	out := &model.ConsentOutput{
+		ConsentID: handlerTestConsentID,
+		Purposes: []model.ConsentPurposeOutput{{
+			DisplayName: &purposeDisplayName,
+			Description: &purposeDescription,
+			Elements: []model.ConsentElementApprovalOutput{{
+				DisplayName: &elementDisplayName,
+				Description: &elementDescription,
 			}},
 		}},
 	}
@@ -213,12 +256,8 @@ func TestHandlerGetConsent_Success(t *testing.T) {
 	handler.getConsent(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-
-	var resp model.ConsentResponse
-	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
-	require.Equal(t, handlerTestConsentID, resp.ConsentID)
-	require.Equal(t, purposeDisplayName, *resp.Purposes[0].DisplayName)
-	require.Equal(t, elementDisplayName, *resp.Purposes[0].Elements[0].DisplayName)
+	require.NotContains(t, rr.Body.String(), "displayName")
+	require.NotContains(t, rr.Body.String(), "description")
 }
 
 func TestHandlerGetConsent_NotFound(t *testing.T) {
@@ -259,7 +298,9 @@ func TestHandlerGetConsent_MissingOrgID(t *testing.T) {
 func TestHandlerListConsents_Success(t *testing.T) {
 	mockSvc := NewMockConsentService(t)
 	purposeDisplayName := "Account management"
+	purposeDescription := "Manage account access"
 	elementDisplayName := "User email address"
+	elementDescription := "The user's email address"
 
 	listOut := &model.ConsentListOutput{
 		Data: []model.ConsentOutput{{
@@ -270,10 +311,12 @@ func TestHandlerListConsents_Success(t *testing.T) {
 				Name:        "account_management",
 				VersionNum:  1,
 				DisplayName: &purposeDisplayName,
+				Description: &purposeDescription,
 				Elements: []model.ConsentElementApprovalOutput{{
 					Name:        "user_email",
 					VersionNum:  1,
 					DisplayName: &elementDisplayName,
+					Description: &elementDescription,
 				}},
 			}},
 		}},
@@ -285,7 +328,7 @@ func TestHandlerListConsents_Success(t *testing.T) {
 	mockSvc.On("SearchConsents", mock.Anything, mock.Anything).Return(listOut, nil)
 
 	handler := newConsentHandler(mockSvc)
-	req := httptest.NewRequest(http.MethodGet, "/consents", nil)
+	req := httptest.NewRequest(http.MethodGet, "/consents?details=true", nil)
 	req.Header.Set(constants.HeaderOrgID, handlerTestOrgID)
 	rr := httptest.NewRecorder()
 
@@ -297,7 +340,42 @@ func TestHandlerListConsents_Success(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(t, resp.Data, 1)
 	require.Equal(t, purposeDisplayName, *resp.Data[0].Purposes[0].DisplayName)
+	require.Equal(t, purposeDescription, *resp.Data[0].Purposes[0].Description)
 	require.Equal(t, elementDisplayName, *resp.Data[0].Purposes[0].Elements[0].DisplayName)
+	require.Equal(t, elementDescription, *resp.Data[0].Purposes[0].Elements[0].Description)
+}
+
+func TestHandlerListConsents_DefaultOmitsDefinitionDetails(t *testing.T) {
+	mockSvc := NewMockConsentService(t)
+	purposeDisplayName := "Account management"
+	purposeDescription := "Manage account access"
+	elementDisplayName := "User email address"
+	elementDescription := "The user's email address"
+
+	listOut := &model.ConsentListOutput{
+		Data: []model.ConsentOutput{{
+			Purposes: []model.ConsentPurposeOutput{{
+				DisplayName: &purposeDisplayName,
+				Description: &purposeDescription,
+				Elements: []model.ConsentElementApprovalOutput{{
+					DisplayName: &elementDisplayName,
+					Description: &elementDescription,
+				}},
+			}},
+		}},
+	}
+	mockSvc.On("SearchConsents", mock.Anything, mock.Anything).Return(listOut, nil)
+
+	handler := newConsentHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/consents", nil)
+	req.Header.Set(constants.HeaderOrgID, handlerTestOrgID)
+	rr := httptest.NewRecorder()
+
+	handler.listConsents(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotContains(t, rr.Body.String(), "displayName")
+	require.NotContains(t, rr.Body.String(), "description")
 }
 
 func TestHandlerListConsents_MissingOrgID(t *testing.T) {

--- a/consent-server/internal/consent/model/consent.go
+++ b/consent-server/internal/consent/model/consent.go
@@ -399,6 +399,7 @@ type ConsentPurposeElementApprovalResponse struct {
 	Namespace   string      `json:"namespace"`
 	Version     string      `json:"version"` // "v1", "v2", ...
 	DisplayName *string     `json:"displayName,omitempty"`
+	Description *string     `json:"description,omitempty"`
 	Mandatory   bool        `json:"mandatory"`
 	Approved    bool        `json:"approved"`
 	Value       interface{} `json:"value,omitempty"`
@@ -410,6 +411,7 @@ type ConsentPurposeResponse struct {
 	Name        string                                  `json:"name"`
 	Version     string                                  `json:"version"` // "v1", "v2", ...
 	DisplayName *string                                 `json:"displayName,omitempty"`
+	Description *string                                 `json:"description,omitempty"`
 	Elements    []ConsentPurposeElementApprovalResponse `json:"elements"`
 }
 

--- a/consent-server/internal/consentpurpose/handler.go
+++ b/consent-server/internal/consentpurpose/handler.go
@@ -379,11 +379,13 @@ func purposeToResponse(p *model.PurposeOutput) model.PurposeResponse {
 		elems := make([]model.PurposeElementResponse, 0, len(p.Elements))
 		for _, e := range p.Elements {
 			elems = append(elems, model.PurposeElementResponse{
-				ElementID: e.ElementID,
-				Name:      e.Name,
-				Namespace: e.Namespace,
-				Version:   fmt.Sprintf("v%d", e.VersionNum),
-				Mandatory: e.Mandatory,
+				ElementID:   e.ElementID,
+				Name:        e.Name,
+				Namespace:   e.Namespace,
+				Version:     fmt.Sprintf("v%d", e.VersionNum),
+				DisplayName: e.DisplayName,
+				Description: e.Description,
+				Mandatory:   e.Mandatory,
 			})
 		}
 		resp.Elements = elems
@@ -404,11 +406,13 @@ func purposeToItem(p *model.PurposeOutput) model.PurposeVersionItem {
 		elems := make([]model.PurposeElementResponse, 0, len(p.Elements))
 		for _, e := range p.Elements {
 			elems = append(elems, model.PurposeElementResponse{
-				ElementID: e.ElementID,
-				Name:      e.Name,
-				Namespace: e.Namespace,
-				Version:   fmt.Sprintf("v%d", e.VersionNum),
-				Mandatory: e.Mandatory,
+				ElementID:   e.ElementID,
+				Name:        e.Name,
+				Namespace:   e.Namespace,
+				Version:     fmt.Sprintf("v%d", e.VersionNum),
+				DisplayName: e.DisplayName,
+				Description: e.Description,
+				Mandatory:   e.Mandatory,
 			})
 		}
 		item.Elements = elems

--- a/consent-server/internal/consentpurpose/handler_test.go
+++ b/consent-server/internal/consentpurpose/handler_test.go
@@ -765,11 +765,21 @@ func TestDeletePurposeVersion_ServiceError(t *testing.T) {
 
 func TestGetPurpose_WithElements(t *testing.T) {
 	mockSvc := NewMockConsentPurposeService(t)
+	elementDisplayName := "Email address"
+	elementDescription := "The user's email address"
 
 	pv := &model.PurposeOutput{
 		ID: testPurposeID, Name: "Marketing", GroupID: testOrgID, VersionNum: 1,
 		Elements: []model.PurposeElementOutput{
-			{ElementID: "eid-1", Name: "email", Namespace: "default", VersionNum: 2, Mandatory: true},
+			{
+				ElementID:   "eid-1",
+				Name:        "email",
+				Namespace:   "default",
+				VersionNum:  2,
+				DisplayName: &elementDisplayName,
+				Description: &elementDescription,
+				Mandatory:   true,
+			},
 		},
 	}
 	mockSvc.On("GetPurpose", mock.Anything, testPurposeID, testOrgID).Return(pv, nil)
@@ -788,19 +798,31 @@ func TestGetPurpose_WithElements(t *testing.T) {
 	require.Len(t, resp.Elements, 1)
 	require.Equal(t, "email", resp.Elements[0].Name)
 	require.Equal(t, "v2", resp.Elements[0].Version)
+	require.Equal(t, elementDisplayName, *resp.Elements[0].DisplayName)
+	require.Equal(t, elementDescription, *resp.Elements[0].Description)
 	require.True(t, resp.Elements[0].Mandatory)
 }
 
 func TestListPurposeVersions_WithElements(t *testing.T) {
 	mockSvc := NewMockConsentPurposeService(t)
 
+	elementDisplayName := "Email address"
+	elementDescription := "The user's email address"
 	out := &model.PurposeVersionListOutput{
 		PurposeID: testPurposeID, Name: "Marketing", GroupID: testOrgID,
 		Versions: []model.PurposeOutput{
 			{
 				ID: testPurposeID, VersionNum: 1,
 				Elements: []model.PurposeElementOutput{
-					{ElementID: "eid-1", Name: "email", Namespace: "default", VersionNum: 1, Mandatory: false},
+					{
+						ElementID:   "eid-1",
+						Name:        "email",
+						Namespace:   "default",
+						VersionNum:  1,
+						DisplayName: &elementDisplayName,
+						Description: &elementDescription,
+						Mandatory:   false,
+					},
 				},
 			},
 		},
@@ -820,6 +842,8 @@ func TestListPurposeVersions_WithElements(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(t, resp.Versions[0].Elements, 1)
 	require.Equal(t, "email", resp.Versions[0].Elements[0].Name)
+	require.Equal(t, elementDisplayName, *resp.Versions[0].Elements[0].DisplayName)
+	require.Equal(t, elementDescription, *resp.Versions[0].Elements[0].Description)
 }
 
 // =============================================================================

--- a/consent-server/internal/consentpurpose/model/consent_purpose.go
+++ b/consent-server/internal/consentpurpose/model/consent_purpose.go
@@ -27,16 +27,16 @@ package model
 // Properties is populated separately from the PURPOSE_PROPERTY table.
 // Elements is populated separately from the PURPOSE_ELEMENT_MAPPING table.
 type PurposeVersion struct {
-	VersionID   string                `db:"VERSION_ID"`
-	ID          string                `db:"ID"`
-	Name        string                `db:"NAME"`
-	GroupID     string                `db:"GROUP_ID"`
-	VersionNum  int                   `db:"VERSION"`
-	DisplayName *string               `db:"DISPLAY_NAME"`
-	Description *string               `db:"DESCRIPTION"`
-	CreatedTime int64                 `db:"CREATED_TIME"`
-	OrgID       string                `db:"ORG_ID"`
-	Properties  map[string]string     `db:"-"`
+	VersionID   string                 `db:"VERSION_ID"`
+	ID          string                 `db:"ID"`
+	Name        string                 `db:"NAME"`
+	GroupID     string                 `db:"GROUP_ID"`
+	VersionNum  int                    `db:"VERSION"`
+	DisplayName *string                `db:"DISPLAY_NAME"`
+	Description *string                `db:"DESCRIPTION"`
+	CreatedTime int64                  `db:"CREATED_TIME"`
+	OrgID       string                 `db:"ORG_ID"`
+	Properties  map[string]string      `db:"-"`
 	Elements    []PurposeMappedElement `db:"-"`
 }
 
@@ -56,6 +56,8 @@ type PurposeMappedElement struct {
 	Name             string  `db:"NAME"`
 	Namespace        string  `db:"NAMESPACE"`
 	VersionNum       int     `db:"VERSION"`
+	DisplayName      *string `db:"DISPLAY_NAME"`
+	Description      *string `db:"DESCRIPTION"`
 	Mandatory        bool    `db:"MANDATORY"`
 	ElementType      string  `db:"TYPE"`
 	Schema           *string `db:"ELEMENT_SCHEMA"`
@@ -118,6 +120,8 @@ type PurposeElementOutput struct {
 	Name             string
 	Namespace        string
 	VersionNum       int
+	DisplayName      *string
+	Description      *string
 	Mandatory        bool
 }
 
@@ -169,18 +173,18 @@ type ElementRefRequest struct {
 // CreatePurposeRequest is the body for POST /consent-purposes.
 // The group-id is read from the request header, not this body.
 type CreatePurposeRequest struct {
-	Name        string             `json:"name"`
-	DisplayName *string            `json:"displayName,omitempty"`
-	Description *string            `json:"description,omitempty"`
-	Properties  map[string]string  `json:"properties,omitempty"`
+	Name        string              `json:"name"`
+	DisplayName *string             `json:"displayName,omitempty"`
+	Description *string             `json:"description,omitempty"`
+	Properties  map[string]string   `json:"properties,omitempty"`
 	Elements    []ElementRefRequest `json:"elements"`
 }
 
 // CreatePurposeVersionRequest is the body for POST /consent-purposes/{purposeId}/versions.
 type CreatePurposeVersionRequest struct {
-	DisplayName *string            `json:"displayName,omitempty"`
-	Description *string            `json:"description,omitempty"`
-	Properties  map[string]string  `json:"properties,omitempty"`
+	DisplayName *string             `json:"displayName,omitempty"`
+	Description *string             `json:"description,omitempty"`
+	Properties  map[string]string   `json:"properties,omitempty"`
 	Elements    []ElementRefRequest `json:"elements"`
 }
 
@@ -190,11 +194,13 @@ type CreatePurposeVersionRequest struct {
 
 // PurposeElementResponse is one element entry within a PurposeResponse or PurposeVersionItem.
 type PurposeElementResponse struct {
-	ElementID string `json:"elementId"`
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-	Version   string `json:"version"` // "v1", "v2", …
-	Mandatory bool   `json:"mandatory"`
+	ElementID   string  `json:"elementId"`
+	Name        string  `json:"name"`
+	Namespace   string  `json:"namespace"`
+	Version     string  `json:"version"` // "v1", "v2", …
+	DisplayName *string `json:"displayName,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Mandatory   bool    `json:"mandatory"`
 }
 
 // PurposeResponse is the response body for:

--- a/consent-server/internal/consentpurpose/service.go
+++ b/consent-server/internal/consentpurpose/service.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
-	"github.com/wso2/openfgc/internal/consentpurpose/model"
 	elementmodel "github.com/wso2/openfgc/internal/consentelement/model"
+	"github.com/wso2/openfgc/internal/consentpurpose/model"
 	dbmodel "github.com/wso2/openfgc/internal/system/database/model"
 	"github.com/wso2/openfgc/internal/system/error/serviceerror"
 	"github.com/wso2/openfgc/internal/system/log"
@@ -552,6 +552,8 @@ func pvToOutput(pv *model.PurposeVersion) *model.PurposeOutput {
 			Name:             e.Name,
 			Namespace:        e.Namespace,
 			VersionNum:       e.VersionNum,
+			DisplayName:      e.DisplayName,
+			Description:      e.Description,
 			Mandatory:        e.Mandatory,
 		})
 	}

--- a/consent-server/internal/consentpurpose/store.go
+++ b/consent-server/internal/consentpurpose/store.go
@@ -116,11 +116,11 @@ var (
 
 	QueryGetPurposeVersionElements = dbmodel.DBQuery{
 		ID: "GET_PURPOSE_VERSION_ELEMENTS",
-		Query: `SELECT m.ELEMENT_VERSION_ID, e.ID AS ELEMENT_ID, e.NAME, e.NAMESPACE, e.VERSION, m.MANDATORY, e.TYPE, e.ELEMENT_SCHEMA
+		Query: `SELECT m.ELEMENT_VERSION_ID, e.ID AS ELEMENT_ID, e.NAME, e.NAMESPACE, e.VERSION, e.DISPLAY_NAME, e.DESCRIPTION, m.MANDATORY, e.TYPE, e.ELEMENT_SCHEMA
 				FROM PURPOSE_ELEMENT_MAPPING m
 				JOIN ELEMENT e ON m.ELEMENT_VERSION_ID = e.VERSION_ID
 				WHERE m.PURPOSE_VERSION_ID = ? AND m.ORG_ID = ?`,
-		PostgresQuery: `SELECT m.ELEMENT_VERSION_ID, e.ID AS ELEMENT_ID, e.NAME, e.NAMESPACE, e.VERSION, m.MANDATORY, e.TYPE, e.ELEMENT_SCHEMA
+		PostgresQuery: `SELECT m.ELEMENT_VERSION_ID, e.ID AS ELEMENT_ID, e.NAME, e.NAMESPACE, e.VERSION, e.DISPLAY_NAME, e.DESCRIPTION, m.MANDATORY, e.TYPE, e.ELEMENT_SCHEMA
 				FROM PURPOSE_ELEMENT_MAPPING m
 				JOIN ELEMENT e ON m.ELEMENT_VERSION_ID = e.VERSION_ID
 				WHERE m.PURPOSE_VERSION_ID = $1 AND m.ORG_ID = $2`,
@@ -618,7 +618,7 @@ func (s *store) batchPopulateElements(dbClient provider.DBClientInterface, versi
 	args = append(args, orgID)
 
 	rawSQL := fmt.Sprintf(
-		`SELECT m.PURPOSE_VERSION_ID, m.ELEMENT_VERSION_ID, e.ID AS ELEMENT_ID, e.NAME, e.NAMESPACE, e.VERSION, m.MANDATORY, e.TYPE, e.ELEMENT_SCHEMA
+		`SELECT m.PURPOSE_VERSION_ID, m.ELEMENT_VERSION_ID, e.ID AS ELEMENT_ID, e.NAME, e.NAMESPACE, e.VERSION, e.DISPLAY_NAME, e.DESCRIPTION, m.MANDATORY, e.TYPE, e.ELEMENT_SCHEMA
 		 FROM PURPOSE_ELEMENT_MAPPING m
 		 JOIN ELEMENT e ON m.ELEMENT_VERSION_ID = e.VERSION_ID
 		 WHERE m.PURPOSE_VERSION_ID IN (%s) AND m.ORG_ID = ?`,
@@ -685,6 +685,8 @@ func mapToPurposeMappedElement(row map[string]interface{}) model.PurposeMappedEl
 		Name:             getString(row, "name"),
 		Namespace:        getString(row, "namespace"),
 		VersionNum:       getInt(row, "version"),
+		DisplayName:      getStringPtr(row, "display_name"),
+		Description:      getStringPtr(row, "description"),
 		Mandatory:        getBool(row, "mandatory"),
 		ElementType:      getString(row, "type"),
 		Schema:           getStringPtr(row, "element_schema"),

--- a/consent-server/internal/consentpurpose/store_test.go
+++ b/consent-server/internal/consentpurpose/store_test.go
@@ -193,6 +193,8 @@ func TestMapToPurposeMappedElement(t *testing.T) {
 		"name":               "email",
 		"namespace":          "default",
 		"version":            int64(3),
+		"display_name":       "Email address",
+		"description":        "The user's email address",
 		"mandatory":          true,
 	}
 	elem := mapToPurposeMappedElement(row)
@@ -201,6 +203,8 @@ func TestMapToPurposeMappedElement(t *testing.T) {
 	require.Equal(t, "email", elem.Name)
 	require.Equal(t, "default", elem.Namespace)
 	require.Equal(t, 3, elem.VersionNum)
+	require.Equal(t, "Email address", *elem.DisplayName)
+	require.Equal(t, "The user's email address", *elem.Description)
 	require.True(t, elem.Mandatory)
 }
 


### PR DESCRIPTION
## Purpose

This PR adds element-level `displayName` and `description` to consent purpose responses and adds purpose/element display names and descriptions to consent GET and search responses when `details=true`.

## Goals

- Expose human-readable metadata for elements in purpose responses.
- Include purpose and element descriptions in detailed consent GET/search responses.
- Keep default consent responses lean when `details=false`.
- Keep API documentation and examples consistent.

## Approach

- Added metadata fields to purpose and consent response models.
- Updated database queries and response mappings.
- Added `details`-aware response handling for consent GET and search endpoints.
- Updated OpenAPI schemas and examples.
- Added regression tests for purpose, consent, and store mappings.

## User stories

As an API consumer, I can retrieve human-readable purpose and element names and descriptions when requesting detailed consent information.

As an API consumer, I can request minimal consent responses without additional display metadata.

## Release note

Consent APIs now support detailed purpose and element display names and descriptions in consent GET/search responses, while preserving lean default responses.

## Documentation

OpenAPI documentation and examples are updated as part of this PR.

## Automation tests

- Unit tests  
  > `go test ./internal/consent ./internal/consentpurpose -count=1` passed.

- Integration tests  
  > Sucsessfully passed

## Security checks

- Followed secure coding standards: Yes
- Ran FindSecurityBugs plugin and verified report: No
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: Yes

## Test environment

Windows development environment; Go unit tests for the consent and consent-purpose packages.